### PR TITLE
feat(io): Implement Structure IO Pipeline and Session Management

### DIFF
--- a/src/io/config.rs
+++ b/src/io/config.rs
@@ -104,7 +104,7 @@ impl Default for TopologyConfig {
 
 /// Topology template for a non-standard (HETATM) residue type.
 #[derive(Debug, Clone)]
-pub struct HeteroTemplate(#[allow(dead_code)] pub(crate) dreid_forge::io::Template); // FIXME: Remove allow dead code when this is actually used.
+pub struct HeteroTemplate(pub(crate) dreid_forge::io::Template);
 
 impl HeteroTemplate {
     /// Parses a MOL2 reader into a hetero residue template.

--- a/src/io/config.rs
+++ b/src/io/config.rs
@@ -19,7 +19,7 @@ pub struct ReadConfig {
     pub protonation: ProtonationConfig,
     /// Bond perception and hetero residue template matching.
     pub topology: TopologyConfig,
-    /// Force-field parameterisation settings.
+    /// Force-field parameterization settings.
     pub ff: ForceFieldConfig,
 }
 
@@ -48,10 +48,10 @@ pub struct ProtonationConfig {
     pub target_ph: Option<f64>,
     /// Histidine tautomer strategy.
     ///
-    /// Default [`HisStrategy::HbNetwork`] optimises tautomer selection via
+    /// Default [`HisStrategy::HbNetwork`] optimizes tautomer selection via
     /// hydrogen-bond network analysis.
     pub his_strategy: HisStrategy,
-    /// Favour doubly-protonated HIP for histidines near carboxylate groups.
+    /// Favor doubly-protonated HIP for histidines near carboxylate groups.
     ///
     /// When `true`, histidines forming salt bridges with ASP⁻, GLU⁻, or the
     /// C-terminal COO⁻ are assigned the HIP form before tautomer selection.
@@ -79,7 +79,7 @@ pub enum HisStrategy {
     Hie,
     /// Assign HID or HIE at random with equal probability.
     Random,
-    /// Optimise tautomer selection via hydrogen-bond network analysis.
+    /// Optimize tautomer selection via hydrogen-bond network analysis.
     #[default]
     HbNetwork,
 }
@@ -120,7 +120,7 @@ impl HeteroTemplate {
     }
 }
 
-/// Force-field parameterisation settings.
+/// Force-field parameterization settings.
 #[derive(Debug, Clone, Default)]
 pub struct ForceFieldConfig {
     /// Custom atom-typing rules in TOML format.
@@ -342,6 +342,6 @@ pub enum DampingStrategy {
     None,
     /// Fixed damping factor `d` where `0.0 < d ≤ 1.0`.
     Fixed(f64),
-    /// Adaptive damping — adjusts automatically based on convergence behaviour.
+    /// Adaptive damping — adjusts automatically based on convergence behavior.
     Auto { initial: f64 },
 }

--- a/src/io/config.rs
+++ b/src/io/config.rs
@@ -164,7 +164,7 @@ pub struct ChargeConfig {
     pub hetero_configs: Vec<HeteroChargeConfig>,
     /// QEq method for hetero residues not listed in [`hetero_configs`](Self::hetero_configs).
     ///
-    /// Default [`HeteroQeqMethod::Embedded`] (embedded QEq, polarised).
+    /// Default [`HeteroQeqMethod::Embedded`] (embedded QEq, polarized).
     pub default_hetero_method: HeteroQeqMethod,
 }
 
@@ -224,7 +224,7 @@ pub struct HeteroChargeConfig {
     pub selector: ResidueSelector,
     /// QEq method to use for this residue.
     ///
-    /// Default [`HeteroQeqMethod::Embedded`] (embedded QEq, polarised).
+    /// Default [`HeteroQeqMethod::Embedded`] (embedded QEq, polarized).
     pub method: HeteroQeqMethod,
 }
 
@@ -233,7 +233,7 @@ pub struct HeteroChargeConfig {
 pub enum HeteroQeqMethod {
     /// Vacuum QEq — residue treated as an isolated molecule.
     Vacuum(QeqConfig),
-    /// Embedded QEq — residue polarised by surrounding fixed charges.
+    /// Embedded QEq — residue polarized by surrounding fixed charges.
     Embedded(EmbeddedQeqConfig),
 }
 

--- a/src/io/config.rs
+++ b/src/io/config.rs
@@ -1,3 +1,4 @@
+use super::error::Error;
 use std::collections::HashSet;
 
 /// Structure file format for biomolecular systems.
@@ -110,11 +111,12 @@ impl HeteroTemplate {
     ///
     /// # Errors
     ///
-    /// Returns [`dreid_forge::io::Error`] if the MOL2 data is malformed or
+    /// Returns [`Error::Template`] if the MOL2 data is malformed or
     /// contains an invalid structure definition.
-    pub fn read_mol2<R: std::io::BufRead>(reader: R) -> Result<Self, dreid_forge::io::Error> {
-        // FIXME: Use Error type from this crate instead of re-exporting from dreid-forge.
-        dreid_forge::io::read_mol2_template(reader).map(Self)
+    pub fn read_mol2<R: std::io::BufRead>(reader: R) -> Result<Self, Error> {
+        dreid_forge::io::read_mol2_template(reader)
+            .map(Self)
+            .map_err(|e| Error::Template(e.to_string()))
     }
 }
 

--- a/src/io/config.rs
+++ b/src/io/config.rs
@@ -1,0 +1,357 @@
+use std::collections::HashSet;
+
+/// Structure file format for biomolecular systems.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Format {
+    /// Protein Data Bank format (`.pdb`).
+    Pdb,
+    /// Macromolecular Crystallographic Information File format (`.cif`).
+    Mmcif,
+}
+
+/// Configuration for [`read()`](super::read).
+#[derive(Debug, Clone, Default)]
+pub struct ReadConfig {
+    /// Atom and residue removal policy.
+    pub clean: CleanConfig,
+    /// Hydrogen addition and protonation state assignment.
+    pub protonation: ProtonationConfig,
+    /// Bond perception and hetero residue template matching.
+    pub topology: TopologyConfig,
+    /// Force-field parameterisation settings.
+    pub ff: ForceFieldConfig,
+}
+
+/// Atom and residue removal policy applied before protonation.
+#[derive(Debug, Clone, Default)]
+pub struct CleanConfig {
+    /// Remove all water molecules (HOH, WAT, etc.).
+    pub remove_water: bool,
+    /// Remove monoatomic ions (Na⁺, Cl⁻, etc.).
+    pub remove_ions: bool,
+    /// Remove all non-ion HETATM residues (ligands, cofactors).
+    pub remove_hetero: bool,
+    /// Remove residues whose names are in this set (case-sensitive).
+    pub remove_residue_names: HashSet<String>,
+    /// If non-empty, keep only residues whose names are in this set.
+    pub keep_residue_names: HashSet<String>,
+}
+
+/// Hydrogen addition and protonation state assignment.
+#[derive(Debug, Clone)]
+pub struct ProtonationConfig {
+    /// Target pH for protonation state assignment (e.g. 7.4).
+    ///
+    /// `None` adds only missing hydrogens using the default protonation
+    /// states already present in the input structure.
+    pub target_ph: Option<f64>,
+    /// Histidine tautomer strategy.
+    ///
+    /// Default [`HisStrategy::HbNetwork`] optimises tautomer selection via
+    /// hydrogen-bond network analysis.
+    pub his_strategy: HisStrategy,
+    /// Favour doubly-protonated HIP for histidines near carboxylate groups.
+    ///
+    /// When `true`, histidines forming salt bridges with ASP⁻, GLU⁻, or the
+    /// C-terminal COO⁻ are assigned the HIP form before tautomer selection.
+    ///
+    /// Default `true`.
+    pub his_salt_bridge: bool,
+}
+
+impl Default for ProtonationConfig {
+    fn default() -> Self {
+        Self {
+            target_ph: None,
+            his_strategy: HisStrategy::default(),
+            his_salt_bridge: true,
+        }
+    }
+}
+
+/// Histidine protonation tautomer strategy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum HisStrategy {
+    /// Force the Nδ-protonated (HID) tautomer for all histidines.
+    Hid,
+    /// Force the Nε-protonated (HIE) tautomer for all histidines.
+    Hie,
+    /// Assign HID or HIE at random with equal probability.
+    Random,
+    /// Optimise tautomer selection via hydrogen-bond network analysis.
+    #[default]
+    HbNetwork,
+}
+
+/// Bond perception and hetero residue template matching.
+#[derive(Debug, Clone)]
+pub struct TopologyConfig {
+    /// Templates for non-standard (HETATM) residue types.
+    pub templates: Vec<HeteroTemplate>,
+    /// S–S distance cutoff for disulfide bond detection (Å).
+    pub disulfide_cutoff: f64,
+}
+
+impl Default for TopologyConfig {
+    fn default() -> Self {
+        Self {
+            templates: Vec::new(),
+            disulfide_cutoff: 2.2,
+        }
+    }
+}
+
+/// Topology template for a non-standard (HETATM) residue type.
+#[derive(Debug, Clone)]
+pub struct HeteroTemplate(#[allow(dead_code)] pub(crate) dreid_forge::io::Template); // FIXME: Remove allow dead code when this is actually used.
+
+impl HeteroTemplate {
+    /// Parses a MOL2 reader into a hetero residue template.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`dreid_forge::io::Error`] if the MOL2 data is malformed or
+    /// contains an invalid structure definition.
+    pub fn read_mol2<R: std::io::BufRead>(reader: R) -> Result<Self, dreid_forge::io::Error> {
+        // FIXME: Use Error type from this crate instead of re-exporting from dreid-forge.
+        dreid_forge::io::read_mol2_template(reader).map(Self)
+    }
+}
+
+/// Force-field parameterisation settings.
+#[derive(Debug, Clone, Default)]
+pub struct ForceFieldConfig {
+    /// Custom atom-typing rules in TOML format.
+    pub rules: Option<String>,
+    /// Custom force-field parameters in TOML format.
+    pub params: Option<String>,
+    /// Van der Waals non-bonded potential form.
+    ///
+    /// Default [`VdwPotential::Buckingham`] (Buckingham exp-6 potential).
+    pub vdw: VdwPotential,
+    /// Partial charge assignment settings.
+    pub charge: ChargeConfig,
+}
+
+/// Van der Waals non-bonded potential form.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum VdwPotential {
+    /// Buckingham exponential-6 potential.
+    #[default]
+    Buckingham,
+    /// Lennard-Jones 12-6 potential.
+    LennardJones,
+}
+
+/// Partial charge assignment settings for the hybrid biomolecule/QEq scheme.
+#[derive(Debug, Clone)]
+pub struct ChargeConfig {
+    /// Charge scheme for standard amino acid residues.
+    ///
+    /// Default [`ProteinScheme::AmberFFSB`] (AMBER ff99SB/ff14SB/ff19SB).
+    pub protein_scheme: ProteinScheme,
+    /// Charge scheme for standard nucleic acid residues.
+    ///
+    /// Default [`NucleicScheme::Amber`] (AMBER OL15/OL21/OL24/bsc1/OL3).
+    pub nucleic_scheme: NucleicScheme,
+    /// Charge model for water molecules.
+    ///
+    /// Default [`WaterScheme::Tip3p`] (TIP3P).
+    pub water_scheme: WaterScheme,
+    /// Per-residue QEq method overrides for specific hetero residues.
+    pub hetero_configs: Vec<HeteroChargeConfig>,
+    /// QEq method for hetero residues not listed in [`hetero_configs`](Self::hetero_configs).
+    ///
+    /// Default [`HeteroQeqMethod::Embedded`] (embedded QEq, polarised).
+    pub default_hetero_method: HeteroQeqMethod,
+}
+
+impl Default for ChargeConfig {
+    fn default() -> Self {
+        Self {
+            protein_scheme: ProteinScheme::default(),
+            nucleic_scheme: NucleicScheme::default(),
+            water_scheme: WaterScheme::default(),
+            hetero_configs: Vec::new(),
+            default_hetero_method: HeteroQeqMethod::default(),
+        }
+    }
+}
+
+/// Classical partial charge scheme for protein residues.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ProteinScheme {
+    /// AMBER ff99SB/ff14SB/ff19SB.
+    #[default]
+    AmberFFSB,
+    /// AMBER ff03.
+    AmberFF03,
+    /// CHARMM22/27/36/36m.
+    Charmm,
+}
+
+/// Classical partial charge scheme for nucleic acid residues.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum NucleicScheme {
+    /// AMBER OL15/OL21/OL24/bsc1/OL3.
+    #[default]
+    Amber,
+    /// CHARMM C27/C36.
+    Charmm,
+}
+
+/// Partial charge model for water molecules.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum WaterScheme {
+    /// TIP3P.
+    #[default]
+    Tip3p,
+    /// TIP3P-FB.
+    Tip3pFb,
+    /// SPC.
+    Spc,
+    /// SPC/E.
+    SpcE,
+    /// OPC3.
+    Opc3,
+}
+
+/// Residue selector for identifying a specific residue by chain position.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ResidueSelector {
+    /// Chain identifier.
+    pub chain_id: String,
+    /// Residue sequence number.
+    pub residue_id: i32,
+    /// Insertion code, if any.
+    pub insertion_code: Option<char>,
+}
+
+/// Per-residue QEq method override for a specific hetero residue.
+#[derive(Debug, Clone)]
+pub struct HeteroChargeConfig {
+    /// Selector identifying the target residue.
+    pub selector: ResidueSelector,
+    /// QEq method to use for this residue.
+    ///
+    /// Default [`HeteroQeqMethod::Embedded`] (embedded QEq, polarised).
+    pub method: HeteroQeqMethod,
+}
+
+/// QEq charge assignment method for hetero residues.
+#[derive(Debug, Clone)]
+pub enum HeteroQeqMethod {
+    /// Vacuum QEq — residue treated as an isolated molecule.
+    Vacuum(QeqConfig),
+    /// Embedded QEq — residue polarised by surrounding fixed charges.
+    Embedded(EmbeddedQeqConfig),
+}
+
+impl Default for HeteroQeqMethod {
+    fn default() -> Self {
+        Self::Embedded(EmbeddedQeqConfig::default())
+    }
+}
+
+/// Configuration for QEq charge equilibration.
+#[derive(Debug, Clone)]
+pub struct QeqConfig {
+    /// Target net charge of the system in elementary charge units.
+    ///
+    /// Default `0.0` (neutral).
+    pub total_charge: f64,
+    /// Numerical solver options.
+    pub solver_options: SolverOptions,
+}
+
+impl Default for QeqConfig {
+    fn default() -> Self {
+        Self {
+            total_charge: 0.0,
+            solver_options: SolverOptions::default(),
+        }
+    }
+}
+
+/// Configuration for embedded QEq calculations.
+#[derive(Debug, Clone)]
+pub struct EmbeddedQeqConfig {
+    /// Radius of the environment atom shell (Å).
+    ///
+    /// Default `10.0` Å.
+    pub cutoff_radius: f64,
+    /// QEq solver configuration for the hetero residue.
+    pub qeq: QeqConfig,
+}
+
+impl Default for EmbeddedQeqConfig {
+    fn default() -> Self {
+        Self {
+            cutoff_radius: 10.0,
+            qeq: QeqConfig::default(),
+        }
+    }
+}
+
+/// Numerical options for the QEq solver.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SolverOptions {
+    /// RMS change in partial charges used as the convergence criterion.
+    ///
+    /// Default `1e-6`.
+    pub tolerance: f64,
+    /// Maximum number of SCF iterations before early termination.
+    ///
+    /// Default `2000`.
+    pub max_iterations: u32,
+    /// Orbital screening scale factor λ (Rappé & Goddard, 1991).
+    ///
+    /// Default `0.5`.
+    pub lambda_scale: f64,
+    /// Update hydrogen hardness each iteration (nonlinear SCF term).
+    ///
+    /// Default `true`.
+    pub hydrogen_scf: bool,
+    /// Basis function type for Coulomb integral evaluation.
+    ///
+    /// Default [`BasisType::Sto`] (Slater-type orbitals).
+    pub basis_type: BasisType,
+    /// Charge update damping strategy.
+    ///
+    /// Default [`DampingStrategy::Auto`] (adaptive damping with initial factor 0.4).
+    pub damping: DampingStrategy,
+}
+
+impl Default for SolverOptions {
+    fn default() -> Self {
+        Self {
+            tolerance: 1.0e-6,
+            max_iterations: 2000,
+            lambda_scale: 0.5,
+            hydrogen_scf: true,
+            basis_type: BasisType::default(),
+            damping: DampingStrategy::Auto { initial: 0.4 },
+        }
+    }
+}
+
+/// Basis function type for Coulomb integral evaluation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BasisType {
+    /// Gaussian-type orbitals — fast, slight approximation.
+    Gto,
+    /// Slater-type orbitals — exact, higher cost.
+    #[default]
+    Sto,
+}
+
+/// Charge update damping strategy for SCF convergence.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum DampingStrategy {
+    /// No damping — fast but may oscillate.
+    None,
+    /// Fixed damping factor `d` where `0.0 < d ≤ 1.0`.
+    Fixed(f64),
+    /// Adaptive damping — adjusts automatically based on convergence behaviour.
+    Auto { initial: f64 },
+}

--- a/src/io/config.rs
+++ b/src/io/config.rs
@@ -144,7 +144,7 @@ pub enum VdwPotential {
 }
 
 /// Partial charge assignment settings for the hybrid biomolecule/QEq scheme.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ChargeConfig {
     /// Charge scheme for standard amino acid residues.
     ///
@@ -164,18 +164,6 @@ pub struct ChargeConfig {
     ///
     /// Default [`HeteroQeqMethod::Embedded`] (embedded QEq, polarised).
     pub default_hetero_method: HeteroQeqMethod,
-}
-
-impl Default for ChargeConfig {
-    fn default() -> Self {
-        Self {
-            protein_scheme: ProteinScheme::default(),
-            nucleic_scheme: NucleicScheme::default(),
-            water_scheme: WaterScheme::default(),
-            hetero_configs: Vec::new(),
-            default_hetero_method: HeteroQeqMethod::default(),
-        }
-    }
 }
 
 /// Classical partial charge scheme for protein residues.

--- a/src/io/convert.rs
+++ b/src/io/convert.rs
@@ -874,3 +874,613 @@ fn dihedral(a: [f64; 3], b: [f64; 3], c: [f64; 3], d: [f64; 3]) -> f32 {
 fn to_vec3(p: [f64; 3]) -> Vec3 {
     Vec3::new(p[0] as f32, p[1] as f32, p[2] as f32)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_abs_diff_eq;
+    use dreid_forge::BondOrder;
+
+    fn ai(name: &str, res: &str, resid: i32, chain: &str) -> AtomResidueInfo {
+        AtomResidueInfo::builder(name, res, resid, chain).build()
+    }
+
+    fn ai_icode(
+        name: &str,
+        res: &str,
+        resid: i32,
+        chain: &str,
+        icode: Option<char>,
+    ) -> AtomResidueInfo {
+        AtomResidueInfo::builder(name, res, resid, chain)
+            .insertion_code_opt(icode)
+            .build()
+    }
+
+    fn ai_full(
+        name: &str,
+        res: &str,
+        resid: i32,
+        chain: &str,
+        icode: Option<char>,
+        std_name: Option<StandardResidue>,
+        cat: ResidueCategory,
+        pos: ResiduePosition,
+    ) -> AtomResidueInfo {
+        AtomResidueInfo::builder(name, res, resid, chain)
+            .insertion_code_opt(icode)
+            .standard_name(std_name)
+            .category(cat)
+            .position(pos)
+            .build()
+    }
+
+    fn bio_with(infos: Vec<AtomResidueInfo>) -> BioMetadata {
+        let mut bio = BioMetadata::new();
+        bio.atom_info = infos;
+        bio
+    }
+
+    fn group_with(indices: Vec<usize>) -> ResidueGroup {
+        ResidueGroup {
+            chain_id: "A".into(),
+            residue_id: 1,
+            insertion_code: None,
+            residue_name: "SER".into(),
+            standard_name: None,
+            category: ResidueCategory::Standard,
+            position: ResiduePosition::None,
+            atom_indices: indices,
+        }
+    }
+
+    fn mobile_meta(sc: Vec<usize>) -> MobileMetadata {
+        MobileMetadata {
+            group_idx: 0,
+            res_type: ResidueType::Ser,
+            n_idx: 0,
+            ca_idx: 0,
+            c_idx: 0,
+            sc_df_indices: sc,
+        }
+    }
+
+    #[test]
+    fn bio_format_maps_pdb() {
+        assert_eq!(bio_format(Format::Pdb), dreid_forge::io::Format::Pdb);
+    }
+
+    #[test]
+    fn bio_format_maps_mmcif() {
+        assert_eq!(bio_format(Format::Mmcif), dreid_forge::io::Format::Mmcif);
+    }
+
+    #[test]
+    fn residue_name_all_mappings_correct() {
+        let cases = [
+            ("GLY", ResidueType::Gly),
+            ("ALA", ResidueType::Ala),
+            ("VAL", ResidueType::Val),
+            ("CYM", ResidueType::Cym),
+            ("CYX", ResidueType::Cyx),
+            ("CYS", ResidueType::Cys),
+            ("SER", ResidueType::Ser),
+            ("THR", ResidueType::Thr),
+            ("PRO", ResidueType::Pro),
+            ("ASP", ResidueType::Asp),
+            ("ASN", ResidueType::Asn),
+            ("ILE", ResidueType::Ile),
+            ("LEU", ResidueType::Leu),
+            ("PHE", ResidueType::Phe),
+            ("TYM", ResidueType::Tym),
+            ("HID", ResidueType::Hid),
+            ("HIE", ResidueType::Hie),
+            ("HIP", ResidueType::Hip),
+            ("TRP", ResidueType::Trp),
+            ("ASH", ResidueType::Ash),
+            ("TYR", ResidueType::Tyr),
+            ("MET", ResidueType::Met),
+            ("GLU", ResidueType::Glu),
+            ("GLN", ResidueType::Gln),
+            ("GLH", ResidueType::Glh),
+            ("ARG", ResidueType::Arg),
+            ("ARN", ResidueType::Arn),
+            ("LYN", ResidueType::Lyn),
+            ("LYS", ResidueType::Lys),
+        ];
+        for (name, expected) in cases {
+            assert_eq!(residue_name_to_type(name), Some(expected), "{name}");
+        }
+    }
+
+    #[test]
+    fn residue_name_unknown_returns_none() {
+        assert!(residue_name_to_type("XYZ").is_none());
+        assert!(residue_name_to_type("").is_none());
+        assert!(residue_name_to_type("HOH").is_none());
+        assert!(residue_name_to_type("ACE").is_none());
+    }
+
+    #[test]
+    fn residue_name_case_sensitive() {
+        assert!(residue_name_to_type("gly").is_none());
+        assert!(residue_name_to_type("Gly").is_none());
+        assert!(residue_name_to_type("GLy").is_none());
+    }
+
+    #[test]
+    fn group_residues_empty() {
+        assert!(group_residues(&bio_with(vec![])).is_empty());
+    }
+
+    #[test]
+    fn group_residues_single_all_fields() {
+        let bio = bio_with(vec![
+            ai_full(
+                "N",
+                "SER",
+                5,
+                "B",
+                Some('X'),
+                Some(StandardResidue::SER),
+                ResidueCategory::Standard,
+                ResiduePosition::NTerminal,
+            ),
+            ai_icode("CA", "SER", 5, "B", Some('X')),
+            ai_icode("C", "SER", 5, "B", Some('X')),
+        ]);
+        let groups = group_residues(&bio);
+        assert_eq!(groups.len(), 1);
+        let g = &groups[0];
+        assert_eq!(g.chain_id, "B");
+        assert_eq!(g.residue_id, 5);
+        assert_eq!(g.insertion_code, Some('X'));
+        assert_eq!(g.residue_name, "SER");
+        assert_eq!(g.standard_name, Some(StandardResidue::SER));
+        assert_eq!(g.category, ResidueCategory::Standard);
+        assert_eq!(g.position, ResiduePosition::NTerminal);
+        assert_eq!(g.atom_indices, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn group_residues_merge() {
+        let bio = bio_with(vec![
+            ai("N", "ALA", 1, "A"),
+            ai("CA", "ALA", 1, "A"),
+            ai("C", "ALA", 1, "A"),
+            ai("O", "ALA", 1, "A"),
+            ai("CB", "ALA", 1, "A"),
+        ]);
+        let groups = group_residues(&bio);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].atom_indices, vec![0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn group_residues_split_by_chain() {
+        let bio = bio_with(vec![ai("N", "ALA", 1, "A"), ai("CA", "ALA", 1, "B")]);
+        let groups = group_residues(&bio);
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups[0].chain_id, "A");
+        assert_eq!(groups[0].atom_indices, vec![0]);
+        assert_eq!(groups[1].chain_id, "B");
+        assert_eq!(groups[1].atom_indices, vec![1]);
+    }
+
+    #[test]
+    fn group_residues_split_by_resid() {
+        let bio = bio_with(vec![ai("N", "SER", 1, "A"), ai("N", "SER", 2, "A")]);
+        let groups = group_residues(&bio);
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups[0].residue_id, 1);
+        assert_eq!(groups[0].atom_indices, vec![0]);
+        assert_eq!(groups[1].residue_id, 2);
+        assert_eq!(groups[1].atom_indices, vec![1]);
+    }
+
+    #[test]
+    fn group_residues_split_by_icode() {
+        let bio = bio_with(vec![
+            ai_icode("N", "SER", 1, "A", None),
+            ai_icode("N", "SER", 1, "A", Some('A')),
+        ]);
+        let groups = group_residues(&bio);
+        assert_eq!(groups.len(), 2);
+        assert!(groups[0].insertion_code.is_none());
+        assert_eq!(groups[0].atom_indices, vec![0]);
+        assert_eq!(groups[1].insertion_code, Some('A'));
+        assert_eq!(groups[1].atom_indices, vec![1]);
+    }
+
+    #[test]
+    fn find_backbone_present() {
+        let bio = bio_with(vec![
+            ai("N", "SER", 1, "A"),
+            ai("CA", "SER", 1, "A"),
+            ai("C", "SER", 1, "A"),
+        ]);
+        let g = group_with(vec![0, 1, 2]);
+        assert_eq!(find_backbone_atom(&g, &bio, "CA"), Some(1));
+    }
+
+    #[test]
+    fn find_backbone_absent() {
+        let bio = bio_with(vec![ai("N", "SER", 1, "A"), ai("CA", "SER", 1, "A")]);
+        let g = group_with(vec![0, 1]);
+        assert_eq!(find_backbone_atom(&g, &bio, "CB"), None);
+    }
+
+    #[test]
+    fn find_backbone_first_occurrence() {
+        let bio = bio_with(vec![
+            ai("CA", "SER", 1, "A"),
+            ai("N", "SER", 1, "A"),
+            ai("CA", "SER", 1, "A"),
+        ]);
+        let g = group_with(vec![0, 1, 2]);
+        assert_eq!(find_backbone_atom(&g, &bio, "CA"), Some(0));
+    }
+
+    #[test]
+    fn atom_to_ref_no_mobile() {
+        let refs = build_atom_to_ref(3, &[]);
+        assert_eq!(
+            refs,
+            vec![AtomRef::Fixed(0), AtomRef::Fixed(1), AtomRef::Fixed(2)]
+        );
+    }
+
+    #[test]
+    fn atom_to_ref_mobile_refs() {
+        let metas = [mobile_meta(vec![1, 3])];
+        let refs = build_atom_to_ref(5, &metas);
+        assert_eq!(
+            refs[1],
+            AtomRef::Mobile {
+                residue: 0,
+                local: 0
+            }
+        );
+        assert_eq!(
+            refs[3],
+            AtomRef::Mobile {
+                residue: 0,
+                local: 1
+            }
+        );
+    }
+
+    #[test]
+    fn atom_to_ref_contiguous_fixed() {
+        let metas = [mobile_meta(vec![1, 3])];
+        let refs = build_atom_to_ref(5, &metas);
+        assert_eq!(refs[0], AtomRef::Fixed(0));
+        assert_eq!(refs[2], AtomRef::Fixed(1));
+        assert_eq!(refs[4], AtomRef::Fixed(2));
+    }
+
+    #[test]
+    fn atom_to_ref_local_order() {
+        let metas = [mobile_meta(vec![3, 1])];
+        let refs = build_atom_to_ref(5, &metas);
+        assert_eq!(
+            refs[3],
+            AtomRef::Mobile {
+                residue: 0,
+                local: 0
+            }
+        );
+        assert_eq!(
+            refs[1],
+            AtomRef::Mobile {
+                residue: 0,
+                local: 1
+            }
+        );
+    }
+
+    #[test]
+    fn atom_to_ref_two_residues() {
+        let metas = [mobile_meta(vec![1, 2]), mobile_meta(vec![4, 5])];
+        let refs = build_atom_to_ref(6, &metas);
+        assert_eq!(refs[0], AtomRef::Fixed(0));
+        assert_eq!(
+            refs[1],
+            AtomRef::Mobile {
+                residue: 0,
+                local: 0
+            }
+        );
+        assert_eq!(
+            refs[2],
+            AtomRef::Mobile {
+                residue: 0,
+                local: 1
+            }
+        );
+        assert_eq!(refs[3], AtomRef::Fixed(1));
+        assert_eq!(
+            refs[4],
+            AtomRef::Mobile {
+                residue: 1,
+                local: 0
+            }
+        );
+        assert_eq!(
+            refs[5],
+            AtomRef::Mobile {
+                residue: 1,
+                local: 1
+            }
+        );
+    }
+
+    #[test]
+    fn vdw_empty_yields_zero_lj() {
+        let m = build_vdw_matrix(2, &[]).unwrap();
+        let VdwMatrix::LennardJones(lj) = m else {
+            panic!("expected LJ");
+        };
+        let zero = LjPair {
+            d0: 0.0,
+            r0_sq: 0.0,
+        };
+        assert_eq!(lj.get(TypeIdx(0), TypeIdx(0)), zero);
+        assert_eq!(lj.get(TypeIdx(0), TypeIdx(1)), zero);
+        assert_eq!(lj.get(TypeIdx(1), TypeIdx(0)), zero);
+        assert_eq!(lj.get(TypeIdx(1), TypeIdx(1)), zero);
+    }
+
+    #[test]
+    fn vdw_lj_symmetric() {
+        let pairs = vec![VdwPairPotential::LennardJones {
+            type1_idx: 0,
+            type2_idx: 1,
+            d0: 3.0,
+            r0_sq: 9.0,
+        }];
+        let m = build_vdw_matrix(2, &pairs).unwrap();
+        let VdwMatrix::LennardJones(lj) = m else {
+            panic!("expected LJ");
+        };
+        let p01 = lj.get(TypeIdx(0), TypeIdx(1));
+        let p10 = lj.get(TypeIdx(1), TypeIdx(0));
+        assert_eq!(p01, p10);
+        assert_ne!(p01.d0, 0.0);
+    }
+
+    #[test]
+    fn vdw_lj_values() {
+        let pairs = vec![VdwPairPotential::LennardJones {
+            type1_idx: 0,
+            type2_idx: 1,
+            d0: 2.5,
+            r0_sq: 6.25,
+        }];
+        let m = build_vdw_matrix(2, &pairs).unwrap();
+        let VdwMatrix::LennardJones(lj) = m else {
+            panic!("expected LJ");
+        };
+        let p = lj.get(TypeIdx(0), TypeIdx(1));
+        assert_eq!(p.d0, 2.5f32);
+        assert_eq!(p.r0_sq, 6.25f32);
+    }
+
+    #[test]
+    fn vdw_buck_symmetric() {
+        let pairs = vec![VdwPairPotential::Buckingham {
+            type1_idx: 0,
+            type2_idx: 1,
+            a: 1.0,
+            b: 2.0,
+            c: 3.0,
+            r_max_sq: 4.0,
+            two_e_max: 5.0,
+        }];
+        let m = build_vdw_matrix(2, &pairs).unwrap();
+        let VdwMatrix::Buckingham(buck) = m else {
+            panic!("expected Buck");
+        };
+        let p01 = buck.get(TypeIdx(0), TypeIdx(1));
+        let p10 = buck.get(TypeIdx(1), TypeIdx(0));
+        assert_eq!(p01, p10);
+        assert_ne!(p01.a, 0.0);
+    }
+
+    #[test]
+    fn vdw_buck_values() {
+        let pairs = vec![VdwPairPotential::Buckingham {
+            type1_idx: 0,
+            type2_idx: 0,
+            a: 10.0,
+            b: 20.0,
+            c: 30.0,
+            r_max_sq: 40.0,
+            two_e_max: 50.0,
+        }];
+        let m = build_vdw_matrix(1, &pairs).unwrap();
+        let VdwMatrix::Buckingham(buck) = m else {
+            panic!("expected Buck");
+        };
+        let p = buck.get(TypeIdx(0), TypeIdx(0));
+        assert_eq!(p.a, 10.0f32);
+        assert_eq!(p.b, 20.0f32);
+        assert_eq!(p.c, 30.0f32);
+        assert_eq!(p.r_max_sq, 40.0f32);
+        assert_eq!(p.two_e_max, 50.0f32);
+    }
+
+    #[test]
+    fn vdw_mixed_returns_error() {
+        let pairs = vec![
+            VdwPairPotential::LennardJones {
+                type1_idx: 0,
+                type2_idx: 0,
+                d0: 1.0,
+                r0_sq: 1.0,
+            },
+            VdwPairPotential::Buckingham {
+                type1_idx: 0,
+                type2_idx: 1,
+                a: 1.0,
+                b: 1.0,
+                c: 1.0,
+                r_max_sq: 1.0,
+                two_e_max: 1.0,
+            },
+        ];
+        assert!(build_vdw_matrix(2, &pairs).is_err());
+    }
+
+    #[test]
+    fn build_bonds_empty() {
+        assert!(build_bonds(&[], &[]).is_empty());
+    }
+
+    #[test]
+    fn build_bonds_fixed_fixed() {
+        let refs = vec![AtomRef::Fixed(0), AtomRef::Fixed(1)];
+        let df = vec![dreid_forge::Bond {
+            i: 0,
+            j: 1,
+            order: BondOrder::Single,
+        }];
+        let bonds = build_bonds(&df, &refs);
+        assert_eq!(bonds.len(), 1);
+        assert_eq!(bonds[0].a, AtomRef::Fixed(0));
+        assert_eq!(bonds[0].b, AtomRef::Fixed(1));
+        assert_eq!(bonds[0].order, BondOrder::Single);
+    }
+
+    #[test]
+    fn build_bonds_mobile_mobile() {
+        let refs = vec![
+            AtomRef::Mobile {
+                residue: 0,
+                local: 0,
+            },
+            AtomRef::Mobile {
+                residue: 0,
+                local: 1,
+            },
+        ];
+        let df = vec![dreid_forge::Bond {
+            i: 0,
+            j: 1,
+            order: BondOrder::Double,
+        }];
+        let bonds = build_bonds(&df, &refs);
+        assert_eq!(bonds.len(), 1);
+        assert_eq!(
+            bonds[0].a,
+            AtomRef::Mobile {
+                residue: 0,
+                local: 0,
+            }
+        );
+        assert_eq!(
+            bonds[0].b,
+            AtomRef::Mobile {
+                residue: 0,
+                local: 1,
+            }
+        );
+        assert_eq!(bonds[0].order, BondOrder::Double);
+    }
+
+    #[test]
+    fn build_bonds_fixed_mobile() {
+        let refs = vec![
+            AtomRef::Fixed(0),
+            AtomRef::Mobile {
+                residue: 0,
+                local: 0,
+            },
+        ];
+        let df = vec![dreid_forge::Bond {
+            i: 0,
+            j: 1,
+            order: BondOrder::Single,
+        }];
+        let bonds = build_bonds(&df, &refs);
+        assert_eq!(bonds.len(), 1);
+        assert_eq!(bonds[0].a, AtomRef::Fixed(0));
+        assert_eq!(
+            bonds[0].b,
+            AtomRef::Mobile {
+                residue: 0,
+                local: 0,
+            }
+        );
+        assert_eq!(bonds[0].order, BondOrder::Single);
+    }
+
+    #[test]
+    fn build_bonds_order_preserved() {
+        let refs = vec![AtomRef::Fixed(0), AtomRef::Fixed(1)];
+        for order in [
+            BondOrder::Single,
+            BondOrder::Double,
+            BondOrder::Triple,
+            BondOrder::Aromatic,
+        ] {
+            let df = vec![dreid_forge::Bond { i: 0, j: 1, order }];
+            let bonds = build_bonds(&df, &refs);
+            assert_eq!(bonds.len(), 1);
+            assert_eq!(bonds[0].order, order);
+        }
+    }
+
+    #[test]
+    fn dihedral_trans() {
+        let angle = dihedral(
+            [1.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [-1.0, 1.0, 0.0],
+        );
+        assert_abs_diff_eq!(angle, std::f32::consts::PI, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn dihedral_cis() {
+        let angle = dihedral(
+            [1.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [1.0, 1.0, 0.0],
+        );
+        assert_abs_diff_eq!(angle, 0.0_f32, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn dihedral_right_angle() {
+        let angle = dihedral(
+            [1.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 1.0, 1.0],
+        );
+        assert_abs_diff_eq!(angle, std::f32::consts::FRAC_PI_2, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn dihedral_sign_flips_on_reflection() {
+        let a = [1.0, 0.0, 0.0];
+        let b = [0.0, 0.0, 0.0];
+        let c = [0.0, 1.0, 0.0];
+        let above = dihedral(a, b, c, [0.0, 1.0, 1.0]);
+        let below = dihedral(a, b, c, [0.0, 1.0, -1.0]);
+        assert_abs_diff_eq!(above, -below, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn to_vec3_zeros() {
+        assert_eq!(to_vec3([0.0, 0.0, 0.0]), Vec3::zero());
+    }
+
+    #[test]
+    fn to_vec3_values() {
+        assert_eq!(to_vec3([1.5, -2.5, 3.5]), Vec3::new(1.5, -2.5, 3.5));
+    }
+}

--- a/src/io/convert.rs
+++ b/src/io/convert.rs
@@ -271,7 +271,7 @@ fn group_residues(bio: &BioMetadata) -> Vec<ResidueGroup> {
     let mut groups: Vec<ResidueGroup> = Vec::new();
 
     for (i, info) in bio.atom_info.iter().enumerate() {
-        let same = groups.last().map_or(false, |g| {
+        let same = groups.last().is_some_and(|g| {
             g.chain_id == info.chain_id
                 && g.residue_id == info.residue_id
                 && g.insertion_code == info.insertion_code

--- a/src/io/convert.rs
+++ b/src/io/convert.rs
@@ -1,0 +1,876 @@
+use super::config::{
+    BasisType, ChargeConfig, CleanConfig, DampingStrategy, EmbeddedQeqConfig, ForceFieldConfig,
+    Format, HeteroQeqMethod, HisStrategy, NucleicScheme, ProteinScheme, ProtonationConfig,
+    QeqConfig, ReadConfig, SolverOptions, TopologyConfig, VdwPotential, WaterScheme,
+};
+use super::error::Error;
+use super::order;
+use super::session::{
+    AtomRef, Bond, FixedAtom, MobileSidechain, ResidueCategory, ResiduePosition, Session,
+    StandardResidue, SystemMetadata,
+};
+use crate::model::{
+    residue::ResidueType,
+    system::{
+        BuckMatrix, BuckPair, FixedAtomPool, ForceFieldParams, HBondParams, LjMatrix, LjPair,
+        Residue, SidechainAtoms, System, VdwMatrix,
+    },
+    types::{TypeIdx, Vec3},
+};
+use dreid_forge::{AtomResidueInfo, BioMetadata, ForgedSystem, VdwPairPotential};
+use std::collections::{HashMap, HashSet};
+use std::io::{BufRead, Write};
+
+/// Reads a biomolecular structure and builds a packing [`Session`].
+///
+/// Parses the input PDB/mmCIF data, cleans, protonates, builds topology,
+/// parameterises with the DREIDING force field, and partitions atoms into
+/// fixed scaffold and mobile sidechains.
+///
+/// # Errors
+///
+/// Returns [`Error::Parse`] if the structure data is malformed,
+/// [`Error::Forge`] if force-field parameterisation fails, or
+/// [`Error::Io`] on OS-level read failure.
+pub fn read<R: BufRead>(reader: R, fmt: Format, cfg: &ReadConfig) -> Result<Session, Error> {
+    let df_sys = dreid_forge::io::BioReader::new(reader, bio_format(fmt))
+        .clean(to_clean(&cfg.clean))
+        .protonate(to_protonation(&cfg.protonation))
+        .topology(to_topology(&cfg.topology))
+        .read()
+        .map_err(|e| Error::Parse(e.to_string()))?;
+
+    let forged = dreid_forge::forge(&df_sys, &to_forge_config(&cfg.ff))
+        .map_err(|e| Error::Forge(e.to_string()))?;
+
+    build(forged)
+}
+
+/// Writes a packing [`Session`] back to a biomolecular structure file.
+///
+/// # Errors
+///
+/// Returns [`Error::Io`] on OS-level write failure.
+pub fn write<W: Write>(writer: W, session: &Session, fmt: Format) -> Result<(), Error> {
+    let df_sys = reconstruct(session);
+    dreid_forge::io::BioWriter::new(writer, bio_format(fmt))
+        .write(&df_sys)
+        .map_err(|e| Error::Io(std::io::Error::other(e.to_string())))
+}
+
+// ---------------------------------------------------------------------------
+// Group A — config translation (pure, infallible)
+// ---------------------------------------------------------------------------
+
+fn bio_format(fmt: Format) -> dreid_forge::io::Format {
+    match fmt {
+        Format::Pdb => dreid_forge::io::Format::Pdb,
+        Format::Mmcif => dreid_forge::io::Format::Mmcif,
+    }
+}
+
+fn to_clean(c: &CleanConfig) -> dreid_forge::io::CleanConfig {
+    dreid_forge::io::CleanConfig {
+        remove_water: c.remove_water,
+        remove_ions: c.remove_ions,
+        remove_hydrogens: false,
+        remove_hetero: c.remove_hetero,
+        remove_residue_names: c.remove_residue_names.clone(),
+        keep_residue_names: c.keep_residue_names.clone(),
+    }
+}
+
+fn to_protonation(c: &ProtonationConfig) -> dreid_forge::io::ProtonationConfig {
+    dreid_forge::io::ProtonationConfig {
+        target_ph: c.target_ph,
+        remove_existing_h: true,
+        his_strategy: to_his_strategy(c.his_strategy),
+        his_salt_bridge: c.his_salt_bridge,
+    }
+}
+
+fn to_his_strategy(s: HisStrategy) -> dreid_forge::io::HisStrategy {
+    match s {
+        HisStrategy::Hid => dreid_forge::io::HisStrategy::DirectHID,
+        HisStrategy::Hie => dreid_forge::io::HisStrategy::DirectHIE,
+        HisStrategy::Random => dreid_forge::io::HisStrategy::Random,
+        HisStrategy::HbNetwork => dreid_forge::io::HisStrategy::HbNetwork,
+    }
+}
+
+fn to_topology(c: &TopologyConfig) -> dreid_forge::io::TopologyConfig {
+    dreid_forge::io::TopologyConfig {
+        hetero_templates: c.templates.iter().map(|t| t.0.clone()).collect(),
+        disulfide_bond_cutoff: c.disulfide_cutoff,
+    }
+}
+
+fn to_forge_config(c: &ForceFieldConfig) -> dreid_forge::ForgeConfig {
+    dreid_forge::ForgeConfig {
+        rules: c.rules.clone(),
+        params: c.params.clone(),
+        charge_method: to_charge_method(&c.charge),
+        bond_potential: dreid_forge::BondPotentialType::Harmonic,
+        angle_potential: dreid_forge::AnglePotentialType::Cosine,
+        vdw_potential: match c.vdw {
+            VdwPotential::Buckingham => dreid_forge::VdwPotentialType::Buckingham,
+            VdwPotential::LennardJones => dreid_forge::VdwPotentialType::LennardJones,
+        },
+    }
+}
+
+fn to_charge_method(c: &ChargeConfig) -> dreid_forge::ChargeMethod {
+    dreid_forge::ChargeMethod::Hybrid(dreid_forge::HybridConfig {
+        protein_scheme: to_protein_scheme(c.protein_scheme),
+        nucleic_scheme: to_nucleic_scheme(c.nucleic_scheme),
+        water_scheme: to_water_scheme(c.water_scheme),
+        ligand_configs: c
+            .hetero_configs
+            .iter()
+            .map(|hc| dreid_forge::LigandChargeConfig {
+                selector: dreid_forge::ResidueSelector::new(
+                    &hc.selector.chain_id,
+                    hc.selector.residue_id,
+                    hc.selector.insertion_code,
+                ),
+                method: to_ligand_method(&hc.method),
+            })
+            .collect(),
+        default_ligand_method: to_ligand_method(&c.default_hetero_method),
+    })
+}
+
+fn to_ligand_method(m: &HeteroQeqMethod) -> dreid_forge::LigandQeqMethod {
+    match m {
+        HeteroQeqMethod::Vacuum(q) => dreid_forge::LigandQeqMethod::Vacuum(to_qeq_config(q)),
+        HeteroQeqMethod::Embedded(e) => dreid_forge::LigandQeqMethod::Embedded(to_embedded_qeq(e)),
+    }
+}
+
+fn to_qeq_config(c: &QeqConfig) -> dreid_forge::QeqConfig {
+    dreid_forge::QeqConfig {
+        total_charge: c.total_charge,
+        solver_options: to_solver_options(&c.solver_options),
+    }
+}
+
+fn to_embedded_qeq(c: &EmbeddedQeqConfig) -> dreid_forge::EmbeddedQeqConfig {
+    dreid_forge::EmbeddedQeqConfig {
+        cutoff_radius: c.cutoff_radius,
+        qeq: to_qeq_config(&c.qeq),
+    }
+}
+
+fn to_solver_options(s: &SolverOptions) -> dreid_forge::SolverOptions {
+    dreid_forge::SolverOptions {
+        tolerance: s.tolerance,
+        max_iterations: s.max_iterations,
+        lambda_scale: s.lambda_scale,
+        hydrogen_scf: s.hydrogen_scf,
+        basis_type: to_basis_type(s.basis_type),
+        damping: to_damping(s.damping),
+    }
+}
+
+fn to_protein_scheme(s: ProteinScheme) -> dreid_forge::ProteinScheme {
+    match s {
+        ProteinScheme::AmberFFSB => dreid_forge::ProteinScheme::AmberFFSB,
+        ProteinScheme::AmberFF03 => dreid_forge::ProteinScheme::AmberFF03,
+        ProteinScheme::Charmm => dreid_forge::ProteinScheme::Charmm,
+    }
+}
+
+fn to_nucleic_scheme(s: NucleicScheme) -> dreid_forge::NucleicScheme {
+    match s {
+        NucleicScheme::Amber => dreid_forge::NucleicScheme::Amber,
+        NucleicScheme::Charmm => dreid_forge::NucleicScheme::Charmm,
+    }
+}
+
+fn to_water_scheme(s: WaterScheme) -> dreid_forge::WaterScheme {
+    match s {
+        WaterScheme::Tip3p => dreid_forge::WaterScheme::Tip3p,
+        WaterScheme::Tip3pFb => dreid_forge::WaterScheme::Tip3pFb,
+        WaterScheme::Spc => dreid_forge::WaterScheme::Spc,
+        WaterScheme::SpcE => dreid_forge::WaterScheme::SpcE,
+        WaterScheme::Opc3 => dreid_forge::WaterScheme::Opc3,
+    }
+}
+
+fn to_basis_type(b: BasisType) -> dreid_forge::BasisType {
+    match b {
+        BasisType::Gto => dreid_forge::BasisType::Gto,
+        BasisType::Sto => dreid_forge::BasisType::Sto,
+    }
+}
+
+fn to_damping(d: DampingStrategy) -> dreid_forge::DampingStrategy {
+    match d {
+        DampingStrategy::None => dreid_forge::DampingStrategy::None,
+        DampingStrategy::Fixed(f) => dreid_forge::DampingStrategy::Fixed(f),
+        DampingStrategy::Auto { initial } => dreid_forge::DampingStrategy::Auto { initial },
+    }
+}
+
+struct ResidueGroup {
+    chain_id: String,
+    residue_id: i32,
+    insertion_code: Option<char>,
+    residue_name: String,
+    standard_name: Option<StandardResidue>,
+    category: ResidueCategory,
+    position: ResiduePosition,
+    atom_indices: Vec<usize>,
+}
+
+struct MobileMetadata {
+    group_idx: usize,
+    res_type: ResidueType,
+    n_idx: usize,
+    ca_idx: usize,
+    c_idx: usize,
+    sc_df_indices: Vec<usize>,
+}
+
+// ---------------------------------------------------------------------------
+// Group B — ForgedSystem -> Session (read path)
+// ---------------------------------------------------------------------------
+
+fn build(forged: ForgedSystem) -> Result<Session, Error> {
+    let bio = forged
+        .system
+        .bio_metadata
+        .as_ref()
+        .ok_or_else(|| Error::Parse("input system lacks biological metadata".into()))?;
+
+    let groups = group_residues(bio);
+    let mobile_metas = classify_mobile(&groups, bio)?;
+    let n_atoms = forged.system.atoms.len();
+    let atom_to_ref = build_atom_to_ref(n_atoms, &mobile_metas);
+    let (ff, h_types) = build_ff(forged.atom_types.len(), &forged.potentials)?;
+    let phi_psi = compute_phi_psi(&forged.system.atoms, bio, &mobile_metas, &groups);
+    let (fixed_pool, fixed_meta) = build_fixed_pool(&forged, bio, &atom_to_ref, &h_types);
+    let (mobile, mobile_meta) = build_mobile(&forged, &groups, &mobile_metas, &phi_psi, &h_types);
+    let bonds = build_bonds(&forged.system.bonds, &atom_to_ref);
+
+    let system = System {
+        mobile,
+        fixed: fixed_pool,
+        ff,
+    };
+    let metadata = SystemMetadata {
+        box_vectors: forged.system.box_vectors,
+        bonds,
+        fixed_atoms: fixed_meta,
+        mobile_residues: mobile_meta,
+    };
+    Ok(Session::new(system, metadata))
+}
+
+fn group_residues(bio: &BioMetadata) -> Vec<ResidueGroup> {
+    let mut groups: Vec<ResidueGroup> = Vec::new();
+
+    for (i, info) in bio.atom_info.iter().enumerate() {
+        let same = groups.last().map_or(false, |g| {
+            g.chain_id == info.chain_id
+                && g.residue_id == info.residue_id
+                && g.insertion_code == info.insertion_code
+        });
+
+        if same {
+            groups.last_mut().unwrap().atom_indices.push(i);
+        } else {
+            groups.push(ResidueGroup {
+                chain_id: info.chain_id.clone(),
+                residue_id: info.residue_id,
+                insertion_code: info.insertion_code,
+                residue_name: info.residue_name.clone(),
+                standard_name: info.standard_name,
+                category: info.category,
+                position: info.position,
+                atom_indices: vec![i],
+            });
+        }
+    }
+
+    groups
+}
+
+fn classify_mobile(
+    groups: &[ResidueGroup],
+    bio: &BioMetadata,
+) -> Result<Vec<MobileMetadata>, Error> {
+    let mut metas = Vec::new();
+
+    for (gi, g) in groups.iter().enumerate() {
+        if g.category != ResidueCategory::Standard {
+            continue;
+        }
+
+        let rt = match residue_name_to_type(&g.residue_name) {
+            Some(rt) if rt.is_packable() => rt,
+            _ => continue,
+        };
+
+        let n_idx = find_backbone_atom(g, bio, "N").ok_or_else(|| {
+            Error::Parse(format!(
+                "missing backbone N in {} {} {}",
+                g.chain_id, g.residue_name, g.residue_id,
+            ))
+        })?;
+        let ca_idx = find_backbone_atom(g, bio, "CA").ok_or_else(|| {
+            Error::Parse(format!(
+                "missing backbone CA in {} {} {}",
+                g.chain_id, g.residue_name, g.residue_id,
+            ))
+        })?;
+        let c_idx = find_backbone_atom(g, bio, "C").ok_or_else(|| {
+            Error::Parse(format!(
+                "missing backbone C in {} {} {}",
+                g.chain_id, g.residue_name, g.residue_id,
+            ))
+        })?;
+
+        let name_to_idx: HashMap<&str, usize> = g
+            .atom_indices
+            .iter()
+            .map(|&i| (bio.atom_info[i].atom_name.as_str(), i))
+            .collect();
+
+        let sc_names = order::sidechain(rt);
+        let mut sc_df_indices = Vec::with_capacity(sc_names.len());
+        for &name in sc_names {
+            let &df_i = name_to_idx.get(name).ok_or_else(|| {
+                Error::Parse(format!(
+                    "missing sidechain atom {name:?} in {} {} {}",
+                    g.chain_id, g.residue_name, g.residue_id,
+                ))
+            })?;
+            sc_df_indices.push(df_i);
+        }
+
+        metas.push(MobileMetadata {
+            group_idx: gi,
+            res_type: rt,
+            n_idx,
+            ca_idx,
+            c_idx,
+            sc_df_indices,
+        });
+    }
+
+    Ok(metas)
+}
+
+fn residue_name_to_type(name: &str) -> Option<ResidueType> {
+    match name {
+        "GLY" => Some(ResidueType::Gly),
+        "ALA" => Some(ResidueType::Ala),
+        "VAL" => Some(ResidueType::Val),
+        "CYM" => Some(ResidueType::Cym),
+        "CYX" => Some(ResidueType::Cyx),
+        "CYS" => Some(ResidueType::Cys),
+        "SER" => Some(ResidueType::Ser),
+        "THR" => Some(ResidueType::Thr),
+        "PRO" => Some(ResidueType::Pro),
+        "ASP" => Some(ResidueType::Asp),
+        "ASN" => Some(ResidueType::Asn),
+        "ILE" => Some(ResidueType::Ile),
+        "LEU" => Some(ResidueType::Leu),
+        "PHE" => Some(ResidueType::Phe),
+        "TYM" => Some(ResidueType::Tym),
+        "HID" => Some(ResidueType::Hid),
+        "HIE" => Some(ResidueType::Hie),
+        "HIP" => Some(ResidueType::Hip),
+        "TRP" => Some(ResidueType::Trp),
+        "ASH" => Some(ResidueType::Ash),
+        "TYR" => Some(ResidueType::Tyr),
+        "MET" => Some(ResidueType::Met),
+        "GLU" => Some(ResidueType::Glu),
+        "GLN" => Some(ResidueType::Gln),
+        "GLH" => Some(ResidueType::Glh),
+        "ARG" => Some(ResidueType::Arg),
+        "ARN" => Some(ResidueType::Arn),
+        "LYN" => Some(ResidueType::Lyn),
+        "LYS" => Some(ResidueType::Lys),
+        _ => None,
+    }
+}
+
+fn find_backbone_atom(group: &ResidueGroup, bio: &BioMetadata, name: &str) -> Option<usize> {
+    group
+        .atom_indices
+        .iter()
+        .copied()
+        .find(|&i| bio.atom_info[i].atom_name == name)
+}
+
+fn build_atom_to_ref(n_atoms: usize, mobile_metas: &[MobileMetadata]) -> Vec<AtomRef> {
+    let mut refs = vec![AtomRef::Fixed(0); n_atoms];
+    let mut is_mobile = vec![false; n_atoms];
+
+    for (r, m) in mobile_metas.iter().enumerate() {
+        for (l, &df_i) in m.sc_df_indices.iter().enumerate() {
+            refs[df_i] = AtomRef::Mobile {
+                residue: r as u32,
+                local: l as u8,
+            };
+            is_mobile[df_i] = true;
+        }
+    }
+
+    let mut fixed_k = 0u32;
+    for i in 0..n_atoms {
+        if !is_mobile[i] {
+            refs[i] = AtomRef::Fixed(fixed_k);
+            fixed_k += 1;
+        }
+    }
+
+    refs
+}
+
+fn build_ff(
+    n_types: usize,
+    potentials: &dreid_forge::Potentials,
+) -> Result<(ForceFieldParams, HashSet<TypeIdx>), Error> {
+    if n_types > 256 {
+        return Err(Error::Parse(format!(
+            "atom type count ({n_types}) exceeds u8 capacity"
+        )));
+    }
+
+    let vdw = build_vdw_matrix(n_types, &potentials.vdw_pairs)?;
+
+    let mut h_types = HashSet::new();
+    let mut acc_types = HashSet::new();
+    let mut params = HashMap::new();
+    for hb in &potentials.h_bonds {
+        let d = TypeIdx(hb.donor_type_idx as u8);
+        let h = TypeIdx(hb.hydrogen_type_idx as u8);
+        let a = TypeIdx(hb.acceptor_type_idx as u8);
+        h_types.insert(h);
+        acc_types.insert(a);
+        params.insert((d, h, a), (hb.d_hb as f32, hb.r_hb_sq as f32));
+    }
+
+    let hbond = HBondParams::new(h_types.clone(), acc_types, params);
+    let ff = ForceFieldParams { vdw, hbond };
+    Ok((ff, h_types))
+}
+
+fn build_vdw_matrix(n: usize, vdw_pairs: &[VdwPairPotential]) -> Result<VdwMatrix, Error> {
+    if vdw_pairs.is_empty() {
+        let zero = LjPair {
+            d0: 0.0,
+            r0_sq: 0.0,
+        };
+        return Ok(VdwMatrix::LennardJones(LjMatrix::new(n, vec![zero; n * n])));
+    }
+
+    let is_lj = matches!(vdw_pairs[0], VdwPairPotential::LennardJones { .. });
+
+    if is_lj {
+        let mut data = vec![
+            LjPair {
+                d0: 0.0,
+                r0_sq: 0.0
+            };
+            n * n
+        ];
+        for p in vdw_pairs {
+            match *p {
+                VdwPairPotential::LennardJones {
+                    type1_idx,
+                    type2_idx,
+                    d0,
+                    r0_sq,
+                } => {
+                    let pair = LjPair {
+                        d0: d0 as f32,
+                        r0_sq: r0_sq as f32,
+                    };
+                    data[type1_idx * n + type2_idx] = pair;
+                    data[type2_idx * n + type1_idx] = pair;
+                }
+                _ => return Err(Error::Parse("mixed VdW potential variants".into())),
+            }
+        }
+        Ok(VdwMatrix::LennardJones(LjMatrix::new(n, data)))
+    } else {
+        let zero = BuckPair {
+            a: 0.0,
+            b: 0.0,
+            c: 0.0,
+            r_max_sq: 0.0,
+            two_e_max: 0.0,
+        };
+        let mut data = vec![zero; n * n];
+        for p in vdw_pairs {
+            match *p {
+                VdwPairPotential::Buckingham {
+                    type1_idx,
+                    type2_idx,
+                    a,
+                    b,
+                    c,
+                    r_max_sq,
+                    two_e_max,
+                } => {
+                    let pair = BuckPair {
+                        a: a as f32,
+                        b: b as f32,
+                        c: c as f32,
+                        r_max_sq: r_max_sq as f32,
+                        two_e_max: two_e_max as f32,
+                    };
+                    data[type1_idx * n + type2_idx] = pair;
+                    data[type2_idx * n + type1_idx] = pair;
+                }
+                _ => return Err(Error::Parse("mixed VdW potential variants".into())),
+            }
+        }
+        Ok(VdwMatrix::Buckingham(BuckMatrix::new(n, data)))
+    }
+}
+
+fn compute_phi_psi(
+    atoms: &[dreid_forge::Atom],
+    bio: &BioMetadata,
+    mobile_metas: &[MobileMetadata],
+    groups: &[ResidueGroup],
+) -> Vec<(f32, f32)> {
+    let mut chain_groups: HashMap<&str, Vec<usize>> = HashMap::new();
+    for (gi, g) in groups.iter().enumerate() {
+        chain_groups
+            .entry(g.chain_id.as_str())
+            .or_default()
+            .push(gi);
+    }
+
+    let mut group_chain_pos: HashMap<usize, usize> = HashMap::new();
+    for indices in chain_groups.values() {
+        for (pos, &gi) in indices.iter().enumerate() {
+            group_chain_pos.insert(gi, pos);
+        }
+    }
+
+    mobile_metas
+        .iter()
+        .map(|m| {
+            let g = &groups[m.group_idx];
+            let chain_idx = &chain_groups[g.chain_id.as_str()];
+            let pos = group_chain_pos[&m.group_idx];
+
+            let phi = if pos > 0 {
+                let prev_g = &groups[chain_idx[pos - 1]];
+                find_backbone_atom(prev_g, bio, "C")
+                    .map(|ci| {
+                        dihedral(
+                            atoms[ci].position,
+                            atoms[m.n_idx].position,
+                            atoms[m.ca_idx].position,
+                            atoms[m.c_idx].position,
+                        )
+                    })
+                    .unwrap_or(0.0)
+            } else {
+                0.0
+            };
+
+            let psi = if pos + 1 < chain_idx.len() {
+                let next_g = &groups[chain_idx[pos + 1]];
+                find_backbone_atom(next_g, bio, "N")
+                    .map(|ni| {
+                        dihedral(
+                            atoms[m.n_idx].position,
+                            atoms[m.ca_idx].position,
+                            atoms[m.c_idx].position,
+                            atoms[ni].position,
+                        )
+                    })
+                    .unwrap_or(0.0)
+            } else {
+                0.0
+            };
+
+            (phi, psi)
+        })
+        .collect()
+}
+
+fn build_fixed_pool(
+    forged: &ForgedSystem,
+    bio: &BioMetadata,
+    atom_to_ref: &[AtomRef],
+    h_types: &HashSet<TypeIdx>,
+) -> (FixedAtomPool, Vec<FixedAtom>) {
+    let n_fixed = atom_to_ref
+        .iter()
+        .filter(|r| matches!(r, AtomRef::Fixed(_)))
+        .count();
+
+    let mut positions = Vec::with_capacity(n_fixed);
+    let mut types = Vec::with_capacity(n_fixed);
+    let mut charges = Vec::with_capacity(n_fixed);
+    let mut donor_for_h = vec![u32::MAX; n_fixed];
+    let mut fixed_meta = Vec::with_capacity(n_fixed);
+
+    for (i, atom_ref) in atom_to_ref.iter().enumerate() {
+        if !matches!(atom_ref, AtomRef::Fixed(_)) {
+            continue;
+        }
+        let pos = forged.system.atoms[i].position;
+        positions.push(Vec3::new(pos[0] as f32, pos[1] as f32, pos[2] as f32));
+        types.push(TypeIdx(forged.atom_properties[i].type_idx as u8));
+        charges.push(forged.atom_properties[i].charge as f32);
+
+        let info = &bio.atom_info[i];
+        fixed_meta.push(FixedAtom {
+            atom_name: info.atom_name.clone(),
+            residue_name: info.residue_name.clone(),
+            residue_id: info.residue_id,
+            chain_id: info.chain_id.clone(),
+            insertion_code: info.insertion_code,
+            standard_name: info.standard_name,
+            category: info.category,
+            position: info.position,
+            element: forged.system.atoms[i].element,
+        });
+    }
+
+    for b in &forged.system.bonds {
+        if let (AtomRef::Fixed(fa), AtomRef::Fixed(fb)) = (atom_to_ref[b.i], atom_to_ref[b.j]) {
+            let (fa, fb) = (fa as usize, fb as usize);
+            if h_types.contains(&types[fa]) {
+                donor_for_h[fa] = fb as u32;
+            }
+            if h_types.contains(&types[fb]) {
+                donor_for_h[fb] = fa as u32;
+            }
+        }
+    }
+
+    let pool = FixedAtomPool {
+        positions,
+        types,
+        charges,
+        donor_for_h,
+    };
+    (pool, fixed_meta)
+}
+
+fn build_mobile(
+    forged: &ForgedSystem,
+    groups: &[ResidueGroup],
+    mobile_metas: &[MobileMetadata],
+    phi_psi: &[(f32, f32)],
+    h_types: &HashSet<TypeIdx>,
+) -> (Vec<Residue>, Vec<MobileSidechain>) {
+    let mut df_to_local: HashMap<usize, (usize, u8)> = HashMap::new();
+    for (r, m) in mobile_metas.iter().enumerate() {
+        for (l, &df_i) in m.sc_df_indices.iter().enumerate() {
+            df_to_local.insert(df_i, (r, l as u8));
+        }
+    }
+
+    let mut donors: Vec<Vec<u8>> = mobile_metas
+        .iter()
+        .map(|m| vec![u8::MAX; m.sc_df_indices.len()])
+        .collect();
+
+    for b in &forged.system.bonds {
+        let (opt_a, opt_b) = (df_to_local.get(&b.i), df_to_local.get(&b.j));
+        if let (Some(&(ra, la)), Some(&(rb, lb))) = (opt_a, opt_b) {
+            if ra != rb {
+                continue;
+            }
+            let type_a = TypeIdx(forged.atom_properties[b.i].type_idx as u8);
+            let type_b = TypeIdx(forged.atom_properties[b.j].type_idx as u8);
+            if h_types.contains(&type_a) {
+                donors[ra][la as usize] = lb;
+            }
+            if h_types.contains(&type_b) {
+                donors[rb][lb as usize] = la;
+            }
+        }
+    }
+
+    let mut residues = Vec::with_capacity(mobile_metas.len());
+    let mut meta = Vec::with_capacity(mobile_metas.len());
+
+    for (r, m) in mobile_metas.iter().enumerate() {
+        let g = &groups[m.group_idx];
+        let (phi, psi) = phi_psi[r];
+        let anchor = [
+            to_vec3(forged.system.atoms[m.n_idx].position),
+            to_vec3(forged.system.atoms[m.ca_idx].position),
+            to_vec3(forged.system.atoms[m.c_idx].position),
+        ];
+
+        let n_sc = m.sc_df_indices.len();
+        let mut coords = Vec::with_capacity(n_sc);
+        let mut types = Vec::with_capacity(n_sc);
+        let mut charges = Vec::with_capacity(n_sc);
+
+        for &df_i in &m.sc_df_indices {
+            coords.push(to_vec3(forged.system.atoms[df_i].position));
+            types.push(TypeIdx(forged.atom_properties[df_i].type_idx as u8));
+            charges.push(forged.atom_properties[df_i].charge as f32);
+        }
+
+        let residue = Residue::new(
+            m.res_type,
+            anchor,
+            phi,
+            psi,
+            SidechainAtoms {
+                coords: &coords,
+                types: &types,
+                charges: &charges,
+                donor_of_h: &donors[r],
+            },
+        )
+        .expect("packable ResidueType must produce Some");
+        residues.push(residue);
+
+        meta.push(MobileSidechain {
+            residue_name: g.residue_name.clone(),
+            residue_id: g.residue_id,
+            chain_id: g.chain_id.clone(),
+            insertion_code: g.insertion_code,
+            standard_name: g.standard_name,
+            category: g.category,
+            position: g.position,
+            elements: m
+                .sc_df_indices
+                .iter()
+                .map(|&df_i| forged.system.atoms[df_i].element)
+                .collect(),
+        });
+    }
+
+    (residues, meta)
+}
+
+fn build_bonds(df_bonds: &[dreid_forge::Bond], atom_to_ref: &[AtomRef]) -> Vec<Bond> {
+    df_bonds
+        .iter()
+        .map(|b| Bond {
+            a: atom_to_ref[b.i],
+            b: atom_to_ref[b.j],
+            order: b.order,
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Group C — Session -> dreid_forge::System (write path)
+// ---------------------------------------------------------------------------
+
+fn reconstruct(session: &Session) -> dreid_forge::System {
+    let meta = session.metadata();
+    let sys = &session.system;
+    let n_fixed = sys.fixed.positions.len();
+    let n_mobile_atoms: usize = sys.mobile.iter().map(|r| r.sidechain().len()).sum();
+    let n_total = n_fixed + n_mobile_atoms;
+
+    let mut atoms = Vec::with_capacity(n_total);
+    let mut atom_info = Vec::with_capacity(n_total);
+
+    for (k, fa) in meta.fixed_atoms.iter().enumerate() {
+        let p = sys.fixed.positions[k];
+        atoms.push(dreid_forge::Atom::new(
+            fa.element,
+            [p.x as f64, p.y as f64, p.z as f64],
+        ));
+        atom_info.push(
+            AtomResidueInfo::builder(&fa.atom_name, &fa.residue_name, fa.residue_id, &fa.chain_id)
+                .insertion_code_opt(fa.insertion_code)
+                .standard_name(fa.standard_name)
+                .category(fa.category)
+                .position(fa.position)
+                .build(),
+        );
+    }
+
+    for (residue, ms) in sys.mobile.iter().zip(meta.mobile_residues.iter()) {
+        let rt = residue_name_to_type(&ms.residue_name)
+            .expect("MobileSidechain always maps to a valid ResidueType");
+        let sc_names = order::sidechain(rt);
+        for (l, &name) in sc_names.iter().enumerate() {
+            let pos = residue.sidechain()[l];
+            atoms.push(dreid_forge::Atom::new(
+                ms.elements[l],
+                [pos.x as f64, pos.y as f64, pos.z as f64],
+            ));
+            atom_info.push(
+                AtomResidueInfo::builder(name, &ms.residue_name, ms.residue_id, &ms.chain_id)
+                    .insertion_code_opt(ms.insertion_code)
+                    .standard_name(ms.standard_name)
+                    .category(ms.category)
+                    .position(ms.position)
+                    .build(),
+            );
+        }
+    }
+
+    let mobile_offsets: Vec<usize> = sys
+        .mobile
+        .iter()
+        .scan(0usize, |acc, r| {
+            let offset = *acc;
+            *acc += r.sidechain().len();
+            Some(offset)
+        })
+        .collect();
+
+    let atom_ref_to_flat = |ar: AtomRef| -> usize {
+        match ar {
+            AtomRef::Fixed(k) => k as usize,
+            AtomRef::Mobile { residue, local } => {
+                n_fixed + mobile_offsets[residue as usize] + local as usize
+            }
+        }
+    };
+
+    let bonds: Vec<dreid_forge::Bond> = meta
+        .bonds
+        .iter()
+        .map(|b| dreid_forge::Bond {
+            i: atom_ref_to_flat(b.a),
+            j: atom_ref_to_flat(b.b),
+            order: b.order,
+        })
+        .collect();
+
+    let mut bio = BioMetadata::with_capacity(n_total);
+    bio.atom_info = atom_info;
+
+    dreid_forge::System {
+        atoms,
+        bonds,
+        box_vectors: meta.box_vectors,
+        bio_metadata: Some(bio),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Group D — math helpers
+// ---------------------------------------------------------------------------
+
+fn dihedral(a: [f64; 3], b: [f64; 3], c: [f64; 3], d: [f64; 3]) -> f32 {
+    let (a, b, c, d) = (to_vec3(a), to_vec3(b), to_vec3(c), to_vec3(d));
+    let b1 = b - a;
+    let b2 = c - b;
+    let b3 = d - c;
+    let n1 = b1.cross(b2);
+    let n2 = b2.cross(b3);
+    let x = n1.dot(n2) * b2.len();
+    let y = n1.cross(b2).dot(n2);
+    y.atan2(x)
+}
+
+fn to_vec3(p: [f64; 3]) -> Vec3 {
+    Vec3::new(p[0] as f32, p[1] as f32, p[2] as f32)
+}

--- a/src/io/convert.rs
+++ b/src/io/convert.rs
@@ -24,13 +24,13 @@ use std::io::{BufRead, Write};
 /// Reads a biomolecular structure and builds a packing [`Session`].
 ///
 /// Parses the input PDB/mmCIF data, cleans, protonates, builds topology,
-/// parameterises with the DREIDING force field, and partitions atoms into
+/// parameterizes with the DREIDING force field, and partitions atoms into
 /// fixed scaffold and mobile sidechains.
 ///
 /// # Errors
 ///
 /// Returns [`Error::Parse`] if the structure data is malformed,
-/// [`Error::Forge`] if force-field parameterisation fails, or
+/// [`Error::Forge`] if force-field parameterization fails, or
 /// [`Error::Io`] on OS-level read failure.
 pub fn read<R: BufRead>(reader: R, fmt: Format, cfg: &ReadConfig) -> Result<Session, Error> {
     let df_sys = dreid_forge::io::BioReader::new(reader, bio_format(fmt))

--- a/src/io/error.rs
+++ b/src/io/error.rs
@@ -1,0 +1,21 @@
+use thiserror::Error;
+
+/// Errors that can occur during structure file I/O.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// OS-level read or write failure.
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    /// PDB/mmCIF bio-structure load failure.
+    #[error("parse error: {0}")]
+    Parse(String),
+
+    /// MOL2 hetero template parse failure.
+    #[error("template parse error: {0}")]
+    Template(String),
+
+    /// Force field parameterization failure.
+    #[error("{0}")]
+    Forge(String),
+}

--- a/src/io/error.rs
+++ b/src/io/error.rs
@@ -15,7 +15,7 @@ pub enum Error {
     #[error("template parse error: {0}")]
     Template(String),
 
-    /// Force field parameterization failure.
-    #[error("{0}")]
+    /// Force-field parameterization failure.
+    #[error("force-field parameterization error: {0}")]
     Forge(String),
 }

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,0 +1,1 @@
+pub mod order;

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,3 +1,4 @@
 pub mod config;
 pub mod error;
 pub mod order;
+pub mod session;

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,4 +1,45 @@
-pub mod config;
-pub mod error;
-pub mod order;
-pub mod session;
+//! Packing session I/O — reading and writing biomolecular structures.
+//!
+//! This module converts between molecular structure files and the [`Session`]
+//! type used by the packing engine. Reading parses the file, runs force-field
+//! parameterisation via `dreid-forge`, and partitions atoms into a fixed
+//! scaffold and a set of mobile sidechains ready for repacking. Writing
+//! reconstructs coordinates from a packed session and serialises them back to
+//! the original file format.
+//!
+//! # Supported Formats
+//!
+//! | Format | Read | Write | Use Case |
+//! |-|-|-|-|
+//! | PDB | ✓ | ✓ | Biomolecules |
+//! | mmCIF | ✓ | ✓ | Biomolecules (modern PDB) |
+//!
+//! # Entry Points
+//!
+//! - [`read()`] — Parse a structure file into a [`Session`].
+//! - [`write()`] — Serialise a [`Session`] back to a structure file.
+//!
+//! # Configuration
+//!
+//! All read-time options are bundled in [`ReadConfig`]:
+//!
+//! - [`CleanConfig`] — Remove water, ions, and hetero residues.
+//! - [`ProtonationConfig`] — Add missing hydrogens; resolve His tautomers.
+//! - [`TopologyConfig`] — Bond perception and hetero residue templates.
+//! - [`ForceFieldConfig`] — DREIDING parameterisation and charge method.
+
+mod config;
+mod convert;
+mod error;
+mod order;
+mod session;
+
+pub use config::{
+    BasisType, ChargeConfig, CleanConfig, DampingStrategy, EmbeddedQeqConfig, ForceFieldConfig,
+    Format, HeteroChargeConfig, HeteroQeqMethod, HeteroTemplate, HisStrategy, NucleicScheme,
+    ProteinScheme, ProtonationConfig, QeqConfig, ReadConfig, ResidueSelector, SolverOptions,
+    TopologyConfig, VdwPotential, WaterScheme,
+};
+pub use convert::{read, write};
+pub use error::Error;
+pub use session::Session;

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -2,9 +2,9 @@
 //!
 //! This module converts between molecular structure files and the [`Session`]
 //! type used by the packing engine. Reading parses the file, runs force-field
-//! parameterisation via `dreid-forge`, and partitions atoms into a fixed
+//! parameterization via `dreid-forge`, and partitions atoms into a fixed
 //! scaffold and a set of mobile sidechains ready for repacking. Writing
-//! reconstructs coordinates from a packed session and serialises them back to
+//! reconstructs coordinates from a packed session and serializes them back to
 //! the original file format.
 //!
 //! # Supported Formats
@@ -17,7 +17,7 @@
 //! # Entry Points
 //!
 //! - [`read()`] — Parse a structure file into a [`Session`].
-//! - [`write()`] — Serialise a [`Session`] back to a structure file.
+//! - [`write()`] — Serialize a [`Session`] back to a structure file.
 //!
 //! # Configuration
 //!
@@ -26,7 +26,7 @@
 //! - [`CleanConfig`] — Remove water, ions, and hetero residues.
 //! - [`ProtonationConfig`] — Add missing hydrogens; resolve His tautomers.
 //! - [`TopologyConfig`] — Bond perception and hetero residue templates.
-//! - [`ForceFieldConfig`] — DREIDING parameterisation and charge method.
+//! - [`ForceFieldConfig`] — DREIDING parameterization and charge method.
 
 mod config;
 mod convert;

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,1 +1,2 @@
+pub mod config;
 pub mod order;

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,2 +1,3 @@
 pub mod config;
+pub mod error;
 pub mod order;

--- a/src/io/order.rs
+++ b/src/io/order.rs
@@ -1,0 +1,37 @@
+use crate::model::residue::ResidueType;
+
+/// Sidechain atom names for each residue type, in the same order as `rotamer::SidechainCoords::as_slice()`.
+#[rustfmt::skip]
+pub fn sidechain(rt: ResidueType) -> &'static [&'static str] {
+    match rt {
+        ResidueType::Gly => &[],
+        ResidueType::Ala => &["CB", "HB1", "HB2", "HB3"],
+        ResidueType::Val => &["CB", "CG1", "CG2", "HB", "HG11", "HG12", "HG13", "HG21", "HG22", "HG23"],
+        ResidueType::Cym => &["CB", "SG", "HB2", "HB3"],
+        ResidueType::Cyx => &["CB", "SG", "HB2", "HB3"],
+        ResidueType::Cys => &["CB", "SG", "HB2", "HB3", "HG"],
+        ResidueType::Ser => &["CB", "OG", "HB2", "HB3", "HG"],
+        ResidueType::Thr => &["CB", "OG1", "CG2", "HB", "HG1", "HG21", "HG22", "HG23"],
+        ResidueType::Pro => &["CB", "CG", "CD", "HB2", "HB3", "HG2", "HG3", "HD2", "HD3"],
+        ResidueType::Asp => &["CB", "CG", "OD1", "OD2", "HB2", "HB3"],
+        ResidueType::Asn => &["CB", "CG", "OD1", "ND2", "HB2", "HB3", "HD21", "HD22"],
+        ResidueType::Ile => &["CB", "CG1", "CG2", "CD1", "HB", "HG12", "HG13", "HG21", "HG22", "HG23", "HD11", "HD12", "HD13"],
+        ResidueType::Leu => &["CB", "CG", "CD1", "CD2", "HB2", "HB3", "HG", "HD11", "HD12", "HD13", "HD21", "HD22", "HD23"],
+        ResidueType::Phe => &["CB", "CG", "CD1", "CD2", "CE1", "CE2", "CZ", "HB2", "HB3", "HD1", "HD2", "HE1", "HE2", "HZ"],
+        ResidueType::Tym => &["CB", "CG", "CD1", "CD2", "CE1", "CE2", "CZ", "OH", "HB2", "HB3", "HD1", "HD2", "HE1", "HE2"],
+        ResidueType::Hid => &["CB", "CG", "ND1", "CD2", "CE1", "NE2", "HB2", "HB3", "HD1", "HD2", "HE1"],
+        ResidueType::Hie => &["CB", "CG", "ND1", "CD2", "CE1", "NE2", "HB2", "HB3", "HD2", "HE1", "HE2"],
+        ResidueType::Hip => &["CB", "CG", "ND1", "CD2", "CE1", "NE2", "HB2", "HB3", "HD1", "HD2", "HE1", "HE2"],
+        ResidueType::Trp => &["CB", "CG", "CD1", "CD2", "NE1", "CE2", "CE3", "CZ2", "CZ3", "CH2", "HB2", "HB3", "HD1", "HE1", "HE3", "HZ2", "HZ3", "HH2"],
+        ResidueType::Ash => &["CB", "CG", "OD1", "OD2", "HB2", "HB3", "HD2"],
+        ResidueType::Tyr => &["CB", "CG", "CD1", "CD2", "CE1", "CE2", "CZ", "OH", "HB2", "HB3", "HD1", "HD2", "HE1", "HE2", "HH"],
+        ResidueType::Met => &["CB", "CG", "SD", "CE", "HB2", "HB3", "HG2", "HG3", "HE1", "HE2", "HE3"],
+        ResidueType::Glu => &["CB", "CG", "CD", "OE1", "OE2", "HB2", "HB3", "HG2", "HG3"],
+        ResidueType::Gln => &["CB", "CG", "CD", "OE1", "NE2", "HB2", "HB3", "HG2", "HG3", "HE21", "HE22"],
+        ResidueType::Glh => &["CB", "CG", "CD", "OE1", "OE2", "HB2", "HB3", "HG2", "HG3", "HE2"],
+        ResidueType::Arg => &["CB", "CG", "CD", "NE", "CZ", "NH1", "NH2", "HB2", "HB3", "HG2", "HG3", "HD2", "HD3", "HE", "HH11", "HH12", "HH21", "HH22"],
+        ResidueType::Arn => &["CB", "CG", "CD", "NE", "CZ", "NH1", "NH2", "HB2", "HB3", "HG2", "HG3", "HD2", "HD3", "HE", "HH11", "HH12", "HH21"],
+        ResidueType::Lyn => &["CB", "CG", "CD", "CE", "NZ", "HB2", "HB3", "HG2", "HG3", "HD2", "HD3", "HE2", "HE3", "HZ1", "HZ2"],
+        ResidueType::Lys => &["CB", "CG", "CD", "CE", "NZ", "HB2", "HB3", "HG2", "HG3", "HD2", "HD3", "HE2", "HE3", "HZ1", "HZ2", "HZ3"],
+    }
+}

--- a/src/io/order.rs
+++ b/src/io/order.rs
@@ -35,3 +35,68 @@ pub fn sidechain(rt: ResidueType) -> &'static [&'static str] {
         ResidueType::Lys => &["CB", "CG", "CD", "CE", "NZ", "HB2", "HB3", "HG2", "HG3", "HD2", "HD3", "HE2", "HE3", "HZ1", "HZ2", "HZ3"],
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::sidechain;
+    use crate::model::residue::ResidueType;
+
+    const ALL: &[ResidueType] = &[
+        ResidueType::Gly,
+        ResidueType::Ala,
+        ResidueType::Val,
+        ResidueType::Cym,
+        ResidueType::Cyx,
+        ResidueType::Cys,
+        ResidueType::Ser,
+        ResidueType::Thr,
+        ResidueType::Pro,
+        ResidueType::Asp,
+        ResidueType::Asn,
+        ResidueType::Ile,
+        ResidueType::Leu,
+        ResidueType::Phe,
+        ResidueType::Tym,
+        ResidueType::Hid,
+        ResidueType::Hie,
+        ResidueType::Hip,
+        ResidueType::Trp,
+        ResidueType::Ash,
+        ResidueType::Tyr,
+        ResidueType::Met,
+        ResidueType::Glu,
+        ResidueType::Gln,
+        ResidueType::Glh,
+        ResidueType::Arg,
+        ResidueType::Arn,
+        ResidueType::Lyn,
+        ResidueType::Lys,
+    ];
+
+    #[test]
+    fn count_matches_n_atoms() {
+        for &rt in ALL {
+            assert_eq!(sidechain(rt).len(), rt.n_atoms() as usize, "{rt:?}");
+        }
+    }
+
+    #[test]
+    fn no_duplicate_atoms() {
+        for &rt in ALL {
+            let mut seen = std::collections::HashSet::new();
+            for &name in sidechain(rt) {
+                assert!(seen.insert(name), "{rt:?}: duplicate {name:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn packable_nonempty_gly_empty() {
+        for &rt in ALL {
+            if rt.is_packable() {
+                assert!(!sidechain(rt).is_empty(), "{rt:?}");
+            }
+        }
+        assert!(sidechain(ResidueType::Gly).is_empty());
+    }
+}

--- a/src/io/session.rs
+++ b/src/io/session.rs
@@ -117,3 +117,466 @@ pub struct MobileSidechain {
     /// Sidechain atom elements, per local atom.
     pub elements: ArrayVec<Element, MAX_SIDECHAIN_ATOMS>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{
+        system::{FixedAtomPool, ForceFieldParams, HBondParams, LjMatrix, VdwMatrix},
+        types::{TypeIdx, Vec3},
+    };
+    use std::collections::{HashMap, HashSet};
+
+    fn empty_system() -> System {
+        System {
+            mobile: vec![],
+            fixed: FixedAtomPool {
+                positions: vec![],
+                types: vec![],
+                charges: vec![],
+                donor_for_h: vec![],
+            },
+            ff: ForceFieldParams {
+                vdw: VdwMatrix::LennardJones(LjMatrix::new(0, vec![])),
+                hbond: HBondParams::new(HashSet::new(), HashSet::new(), HashMap::new()),
+            },
+        }
+    }
+
+    fn system_with_n_fixed(n: usize) -> System {
+        System {
+            mobile: vec![],
+            fixed: FixedAtomPool {
+                positions: vec![Vec3::new(0.0, 0.0, 0.0); n],
+                types: vec![TypeIdx(0); n],
+                charges: vec![0.0f32; n],
+                donor_for_h: vec![u32::MAX; n],
+            },
+            ff: ForceFieldParams {
+                vdw: VdwMatrix::LennardJones(LjMatrix::new(0, vec![])),
+                hbond: HBondParams::new(HashSet::new(), HashSet::new(), HashMap::new()),
+            },
+        }
+    }
+
+    fn empty_metadata() -> SystemMetadata {
+        SystemMetadata {
+            box_vectors: None,
+            bonds: vec![],
+            fixed_atoms: vec![],
+            mobile_residues: vec![],
+        }
+    }
+
+    fn fixed_atom() -> FixedAtom {
+        FixedAtom {
+            atom_name: "CA".to_string(),
+            residue_name: "SER".to_string(),
+            residue_id: 1,
+            chain_id: "A".to_string(),
+            insertion_code: None,
+            standard_name: Some(StandardResidue::SER),
+            category: ResidueCategory::Standard,
+            position: ResiduePosition::Internal,
+            element: Element::C,
+        }
+    }
+
+    fn mobile_sidechain() -> MobileSidechain {
+        MobileSidechain {
+            residue_name: "SER".to_string(),
+            residue_id: 1,
+            chain_id: "A".to_string(),
+            insertion_code: None,
+            standard_name: Some(StandardResidue::SER),
+            category: ResidueCategory::Standard,
+            position: ResiduePosition::Internal,
+            elements: ArrayVec::new(),
+        }
+    }
+
+    #[test]
+    fn atom_ref_variants_are_distinct() {
+        assert_ne!(
+            AtomRef::Fixed(0),
+            AtomRef::Mobile {
+                residue: 0,
+                local: 0
+            }
+        );
+    }
+
+    #[test]
+    fn atom_ref_is_copy() {
+        let a = AtomRef::Fixed(7);
+        let b = a;
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn atom_ref_fixed_roundtrips() {
+        let AtomRef::Fixed(idx) = AtomRef::Fixed(42) else {
+            panic!("unexpected variant");
+        };
+        assert_eq!(idx, 42);
+    }
+
+    #[test]
+    fn atom_ref_mobile_roundtrips() {
+        let AtomRef::Mobile { residue, local } = (AtomRef::Mobile {
+            residue: 5,
+            local: 3,
+        }) else {
+            panic!("unexpected variant");
+        };
+        assert_eq!(residue, 5);
+        assert_eq!(local, 3);
+    }
+
+    #[test]
+    fn atom_ref_fixed_max_index() {
+        let AtomRef::Fixed(idx) = AtomRef::Fixed(u32::MAX) else {
+            panic!("unexpected variant");
+        };
+        assert_eq!(idx, u32::MAX);
+    }
+
+    #[test]
+    fn atom_ref_mobile_max_indices() {
+        let AtomRef::Mobile { residue, local } = (AtomRef::Mobile {
+            residue: u32::MAX,
+            local: u8::MAX,
+        }) else {
+            panic!("unexpected variant");
+        };
+        assert_eq!(residue, u32::MAX);
+        assert_eq!(local, u8::MAX);
+    }
+
+    #[test]
+    fn atom_ref_fixed_eq_same_index() {
+        assert_eq!(AtomRef::Fixed(0), AtomRef::Fixed(0));
+        assert_ne!(AtomRef::Fixed(0), AtomRef::Fixed(1));
+    }
+
+    #[test]
+    fn atom_ref_mobile_eq_same_pair() {
+        assert_eq!(
+            AtomRef::Mobile {
+                residue: 2,
+                local: 1
+            },
+            AtomRef::Mobile {
+                residue: 2,
+                local: 1
+            },
+        );
+        assert_ne!(
+            AtomRef::Mobile {
+                residue: 2,
+                local: 1
+            },
+            AtomRef::Mobile {
+                residue: 2,
+                local: 2
+            },
+        );
+        assert_ne!(
+            AtomRef::Mobile {
+                residue: 2,
+                local: 1
+            },
+            AtomRef::Mobile {
+                residue: 3,
+                local: 1
+            },
+        );
+    }
+
+    #[test]
+    fn bond_stores_all_fields() {
+        let b = Bond {
+            a: AtomRef::Fixed(0),
+            b: AtomRef::Mobile {
+                residue: 1,
+                local: 2,
+            },
+            order: BondOrder::Single,
+        };
+        assert_eq!(b.a, AtomRef::Fixed(0));
+        assert_eq!(
+            b.b,
+            AtomRef::Mobile {
+                residue: 1,
+                local: 2
+            }
+        );
+        assert_eq!(b.order, BondOrder::Single);
+    }
+
+    #[test]
+    fn bond_all_orders_roundtrip() {
+        for order in [
+            BondOrder::Single,
+            BondOrder::Double,
+            BondOrder::Triple,
+            BondOrder::Aromatic,
+        ] {
+            let b = Bond {
+                a: AtomRef::Fixed(0),
+                b: AtomRef::Fixed(1),
+                order,
+            };
+            assert_eq!(b.order, order);
+        }
+    }
+
+    #[test]
+    fn bond_clone_is_equal() {
+        let b = Bond {
+            a: AtomRef::Fixed(3),
+            b: AtomRef::Fixed(7),
+            order: BondOrder::Double,
+        };
+        let c = b.clone();
+        assert_eq!(c.a, b.a);
+        assert_eq!(c.b, b.b);
+        assert_eq!(c.order, b.order);
+    }
+
+    #[test]
+    fn fixed_atom_stores_all_fields() {
+        let fa = FixedAtom {
+            atom_name: "OD1".to_string(),
+            residue_name: "ASP".to_string(),
+            residue_id: -3,
+            chain_id: "B".to_string(),
+            insertion_code: Some('A'),
+            standard_name: Some(StandardResidue::ASP),
+            category: ResidueCategory::Standard,
+            position: ResiduePosition::CTerminal,
+            element: Element::O,
+        };
+        assert_eq!(fa.atom_name, "OD1");
+        assert_eq!(fa.residue_name, "ASP");
+        assert_eq!(fa.residue_id, -3);
+        assert_eq!(fa.chain_id, "B");
+        assert_eq!(fa.insertion_code, Some('A'));
+        assert_eq!(fa.standard_name, Some(StandardResidue::ASP));
+        assert_eq!(fa.category, ResidueCategory::Standard);
+        assert_eq!(fa.position, ResiduePosition::CTerminal);
+        assert_eq!(fa.element, Element::O);
+    }
+
+    #[test]
+    fn fixed_atom_optional_fields_none() {
+        let fa = FixedAtom {
+            atom_name: "O".to_string(),
+            residue_name: "HOH".to_string(),
+            residue_id: 999,
+            chain_id: " ".to_string(),
+            insertion_code: None,
+            standard_name: None,
+            category: ResidueCategory::Hetero,
+            position: ResiduePosition::None,
+            element: Element::O,
+        };
+        assert!(fa.insertion_code.is_none());
+        assert!(fa.standard_name.is_none());
+    }
+
+    #[test]
+    fn fixed_atom_clone_is_equal() {
+        let fa = fixed_atom();
+        let cl = fa.clone();
+        assert_eq!(cl.atom_name, fa.atom_name);
+        assert_eq!(cl.residue_id, fa.residue_id);
+        assert_eq!(cl.element, fa.element);
+        assert_eq!(cl.standard_name, fa.standard_name);
+    }
+
+    #[test]
+    fn mobile_sidechain_stores_all_fields() {
+        let ms = MobileSidechain {
+            residue_name: "TRP".to_string(),
+            residue_id: 100,
+            chain_id: "C".to_string(),
+            insertion_code: Some('B'),
+            standard_name: Some(StandardResidue::TRP),
+            category: ResidueCategory::Standard,
+            position: ResiduePosition::NTerminal,
+            elements: ArrayVec::new(),
+        };
+        assert_eq!(ms.residue_name, "TRP");
+        assert_eq!(ms.residue_id, 100);
+        assert_eq!(ms.chain_id, "C");
+        assert_eq!(ms.insertion_code, Some('B'));
+        assert_eq!(ms.standard_name, Some(StandardResidue::TRP));
+        assert_eq!(ms.category, ResidueCategory::Standard);
+        assert_eq!(ms.position, ResiduePosition::NTerminal);
+    }
+
+    #[test]
+    fn mobile_sidechain_optional_fields_none() {
+        let ms = MobileSidechain {
+            residue_name: "UNK".to_string(),
+            residue_id: 0,
+            chain_id: "A".to_string(),
+            insertion_code: None,
+            standard_name: None,
+            category: ResidueCategory::Hetero,
+            position: ResiduePosition::None,
+            elements: ArrayVec::new(),
+        };
+        assert!(ms.insertion_code.is_none());
+        assert!(ms.standard_name.is_none());
+    }
+
+    #[test]
+    fn mobile_sidechain_elements_empty_on_construction() {
+        assert!(mobile_sidechain().elements.is_empty());
+    }
+
+    #[test]
+    fn mobile_sidechain_elements_fills_to_capacity() {
+        let mut ms = mobile_sidechain();
+        for _ in 0..MAX_SIDECHAIN_ATOMS {
+            ms.elements.push(Element::C);
+        }
+        assert_eq!(ms.elements.len(), MAX_SIDECHAIN_ATOMS);
+    }
+
+    #[test]
+    fn mobile_sidechain_clone_preserves_elements() {
+        let mut ms = mobile_sidechain();
+        ms.elements.push(Element::N);
+        ms.elements.push(Element::O);
+        let cl = ms.clone();
+        assert_eq!(cl.elements.as_slice(), &[Element::N, Element::O]);
+    }
+
+    #[test]
+    fn system_metadata_box_vectors_none_by_default() {
+        assert!(empty_metadata().box_vectors.is_none());
+    }
+
+    #[test]
+    fn system_metadata_box_vectors_roundtrip() {
+        let bv = [[10.0f64, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]];
+        let m = SystemMetadata {
+            box_vectors: Some(bv),
+            ..empty_metadata()
+        };
+        assert_eq!(m.box_vectors, Some(bv));
+    }
+
+    #[test]
+    fn system_metadata_empty_collections() {
+        let m = empty_metadata();
+        assert!(m.bonds.is_empty());
+        assert!(m.fixed_atoms.is_empty());
+        assert!(m.mobile_residues.is_empty());
+    }
+
+    #[test]
+    fn system_metadata_collections_store_given_entries() {
+        let m = SystemMetadata {
+            bonds: vec![
+                Bond {
+                    a: AtomRef::Fixed(0),
+                    b: AtomRef::Fixed(1),
+                    order: BondOrder::Single,
+                },
+                Bond {
+                    a: AtomRef::Fixed(1),
+                    b: AtomRef::Fixed(2),
+                    order: BondOrder::Aromatic,
+                },
+            ],
+            fixed_atoms: vec![fixed_atom(), fixed_atom(), fixed_atom()],
+            mobile_residues: vec![mobile_sidechain()],
+            ..empty_metadata()
+        };
+        assert_eq!(m.bonds.len(), 2);
+        assert_eq!(m.bonds[1].order, BondOrder::Aromatic);
+        assert_eq!(m.fixed_atoms.len(), 3);
+        assert_eq!(m.mobile_residues.len(), 1);
+    }
+
+    #[test]
+    fn session_new_stores_system_and_metadata() {
+        let bv = [[5.0f64, 0.0, 0.0], [0.0, 5.0, 0.0], [0.0, 0.0, 5.0]];
+        let sess = Session::new(
+            empty_system(),
+            SystemMetadata {
+                box_vectors: Some(bv),
+                ..empty_metadata()
+            },
+        );
+        assert_eq!(sess.system.mobile.len(), 0);
+        assert_eq!(sess.metadata().box_vectors, Some(bv));
+    }
+
+    #[test]
+    fn session_metadata_returns_correct_reference() {
+        let bv = [[1.0f64, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 3.0]];
+        let sess = Session::new(
+            empty_system(),
+            SystemMetadata {
+                box_vectors: Some(bv),
+                ..empty_metadata()
+            },
+        );
+        assert_eq!(sess.metadata().box_vectors, Some(bv));
+        assert!(sess.metadata().bonds.is_empty());
+    }
+
+    #[test]
+    fn session_new_with_matching_fixed_atoms() {
+        let n = 4;
+        let sess = Session::new(
+            system_with_n_fixed(n),
+            SystemMetadata {
+                fixed_atoms: vec![fixed_atom(); n],
+                ..empty_metadata()
+            },
+        );
+        assert_eq!(sess.system.fixed.positions.len(), n);
+        assert_eq!(sess.metadata().fixed_atoms.len(), n);
+    }
+
+    #[test]
+    fn session_clone_preserves_all_data() {
+        let bv = [[7.0f64, 0.0, 0.0], [0.0, 7.0, 0.0], [0.0, 0.0, 7.0]];
+        let sess = Session::new(
+            empty_system(),
+            SystemMetadata {
+                box_vectors: Some(bv),
+                ..empty_metadata()
+            },
+        );
+        let cl = sess.clone();
+        assert_eq!(cl.metadata().box_vectors, sess.metadata().box_vectors);
+        assert_eq!(cl.system.mobile.len(), sess.system.mobile.len());
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic]
+    fn session_new_panics_on_mobile_count_mismatch() {
+        Session::new(
+            empty_system(),
+            SystemMetadata {
+                mobile_residues: vec![mobile_sidechain()],
+                ..empty_metadata()
+            },
+        );
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic]
+    fn session_new_panics_on_fixed_count_mismatch() {
+        Session::new(system_with_n_fixed(1), empty_metadata());
+    }
+}

--- a/src/io/session.rs
+++ b/src/io/session.rs
@@ -1,0 +1,119 @@
+use crate::model::system::{MAX_SIDECHAIN_ATOMS, System};
+use arrayvec::ArrayVec;
+
+pub use dreid_forge::{BondOrder, Element, ResidueCategory, ResiduePosition, StandardResidue};
+
+/// A packing session: the molecular system together with its topology and metadata.
+#[derive(Debug, Clone)]
+pub struct Session {
+    /// Packable system (mobile residues + fixed scaffold).
+    pub system: System,
+    // Topology + metadata bookkeeping for biological system.
+    #[allow(dead_code)] // FIXME: Remove allow dead code once metadata is used.
+    metadata: SystemMetadata,
+}
+
+impl Session {
+    /// Creates a session from a `system` and its paired `metadata`.
+    #[allow(dead_code)] // FIXME: Remove allow dead code once this is used.
+    pub(super) fn new(system: System, metadata: SystemMetadata) -> Self {
+        debug_assert_eq!(
+            system.mobile.len(),
+            metadata.mobile_residues.len(),
+            "mobile residue count mismatch: system has {} but metadata has {}",
+            system.mobile.len(),
+            metadata.mobile_residues.len(),
+        );
+        debug_assert_eq!(
+            system.fixed.positions.len(),
+            metadata.fixed_atoms.len(),
+            "fixed atom count mismatch: system has {} but metadata has {}",
+            system.fixed.positions.len(),
+            metadata.fixed_atoms.len(),
+        );
+        Self { system, metadata }
+    }
+
+    /// Topology metadata paired with this session.
+    #[allow(dead_code)] // FIXME: Remove allow dead code once this is used.
+    pub(super) fn metadata(&self) -> &SystemMetadata {
+        &self.metadata
+    }
+}
+
+/// Topology bookkeeping that accompanies a [`System`].
+#[derive(Debug, Clone)]
+pub struct SystemMetadata {
+    /// Periodic box vectors (Å), or `None`.
+    pub box_vectors: Option<[[f64; 3]; 3]>,
+    /// All covalent bonds.
+    pub bonds: Vec<Bond>,
+    /// One entry per atom in `System::fixed`, preserving order.
+    pub fixed_atoms: Vec<FixedAtom>,
+    /// One entry per residue in `System::mobile`, preserving order.
+    pub mobile_residues: Vec<MobileSidechain>,
+}
+
+/// A covalent bond between two atoms.
+#[derive(Debug, Clone)]
+pub struct Bond {
+    /// First endpoint.
+    pub a: AtomRef,
+    /// Second endpoint.
+    pub b: AtomRef,
+    /// Bond order.
+    pub order: BondOrder,
+}
+
+/// Reference to an atom in either the fixed pool or a mobile sidechain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AtomRef {
+    /// Index into fixed atom pool.
+    Fixed(u32),
+    /// Residue index + local atom index into mobile sidechain.
+    Mobile { residue: u32, local: u8 },
+}
+
+/// Topology metadata for one atom in the fixed pool.
+#[derive(Debug, Clone)]
+pub struct FixedAtom {
+    /// Atom name (e.g. `"CA"`, `"OD1"`).
+    pub atom_name: String,
+    /// Residue name (e.g. `"SER"`, `"HOH"`).
+    pub residue_name: String,
+    /// Residue sequence number.
+    pub residue_id: i32,
+    /// Chain identifier.
+    pub chain_id: String,
+    /// Insertion code, or `None` if absent.
+    pub insertion_code: Option<char>,
+    /// Matched standard residue name, or `None` for non-standard/HETATM.
+    pub standard_name: Option<StandardResidue>,
+    /// Residue category (standard, hetero, ion).
+    pub category: ResidueCategory,
+    /// Residue chain position (N-terminal, internal, C-terminal, …).
+    pub position: ResiduePosition,
+    /// Chemical element.
+    pub element: Element,
+}
+
+/// Topology metadata for one mobile residue.
+#[derive(Debug, Clone)]
+pub struct MobileSidechain {
+    /// Residue name.
+    pub residue_name: String,
+    /// Residue sequence number.
+    pub residue_id: i32,
+    /// Chain identifier.
+    pub chain_id: String,
+    /// Insertion code, or `None` if absent.
+    pub insertion_code: Option<char>,
+    /// Matched standard residue name, or `None` for non-standard residues.
+    pub standard_name: Option<StandardResidue>,
+    /// Residue category.
+    pub category: ResidueCategory,
+    /// Residue chain position.
+    pub position: ResiduePosition,
+    /// Sidechain atom elements, per local atom.
+    pub elements: ArrayVec<Element, MAX_SIDECHAIN_ATOMS>,
+}

--- a/src/io/session.rs
+++ b/src/io/session.rs
@@ -8,7 +8,7 @@ pub use dreid_forge::{BondOrder, Element, ResidueCategory, ResiduePosition, Stan
 pub struct Session {
     /// Packable system (mobile residues + fixed scaffold).
     pub system: System,
-    // Topology + metadata bookkeeping for biological system.
+    /// Topology + metadata bookkeeping for biological system.
     metadata: SystemMetadata,
 }
 

--- a/src/io/session.rs
+++ b/src/io/session.rs
@@ -9,13 +9,11 @@ pub struct Session {
     /// Packable system (mobile residues + fixed scaffold).
     pub system: System,
     // Topology + metadata bookkeeping for biological system.
-    #[allow(dead_code)] // FIXME: Remove allow dead code once metadata is used.
     metadata: SystemMetadata,
 }
 
 impl Session {
     /// Creates a session from a `system` and its paired `metadata`.
-    #[allow(dead_code)] // FIXME: Remove allow dead code once this is used.
     pub(super) fn new(system: System, metadata: SystemMetadata) -> Self {
         debug_assert_eq!(
             system.mobile.len(),
@@ -35,7 +33,6 @@ impl Session {
     }
 
     /// Topology metadata paired with this session.
-    #[allow(dead_code)] // FIXME: Remove allow dead code once this is used.
     pub(super) fn metadata(&self) -> &SystemMetadata {
         &self.metadata
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod io;
 pub mod model;
 pub mod pack;

--- a/src/model/system.rs
+++ b/src/model/system.rs
@@ -165,29 +165,95 @@ pub struct ForceFieldParams {
     pub hbond: HBondParams,
 }
 
-/// Flat symmetric VdW matrix.
+/// VdW parameter matrix (LJ 12-6 or Buckingham (EXP-6)).
 #[derive(Debug, Clone)]
-pub struct VdwMatrix {
-    /// Number of atom types (matrix dimension).
-    n: usize,
-    /// Flat symmetric matrix of (D0, R0^2) parameters.
-    data: Vec<(f32, f32)>,
+pub enum VdwMatrix {
+    /// Lennard-Jones 12-6 variant.
+    LennardJones(LjMatrix),
+    /// Buckingham (EXP-6) variant.
+    Buckingham(BuckMatrix),
 }
 
-impl VdwMatrix {
-    /// Creates a VdW parameter matrix of dimension `n × n`.
+/// Pre-computed pair parameters for the LJ 12-6 potential.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LjPair {
+    /// Well depth.
+    pub d0: f32,
+    /// Squared equilibrium distance.
+    pub r0_sq: f32,
+}
+
+/// Pre-computed pair parameters for the Buckingham (EXP-6) potential.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BuckPair {
+    /// Repulsion prefactor A.
+    pub a: f32,
+    /// Repulsion decay B.
+    pub b: f32,
+    /// Attraction coefficient C.
+    pub c: f32,
+    /// Squared distance of the energy maximum.
+    pub r_max_sq: f32,
+    /// Twice the energy value at the maximum.
+    pub two_e_max: f32,
+}
+
+/// Flat symmetric n×n matrix of pre-computed [`LjPair`] parameters.
+#[derive(Debug, Clone)]
+pub struct LjMatrix {
+    /// Number of atom types (matrix dimension).
+    n: usize,
+    /// Flat array of length n*n.
+    data: Box<[LjPair]>,
+}
+
+impl LjMatrix {
+    /// Creates an LJ parameter matrix of dimension `n × n`.
     ///
     /// # Panics
     ///
     /// Panics if `data.len() ≠ n * n`.
-    pub fn new(n: usize, data: Vec<(f32, f32)>) -> Self {
+    pub fn new(n: usize, data: Vec<LjPair>) -> Self {
         assert_eq!(data.len(), n * n, "data.len() must equal n*n");
-        Self { n, data }
+        Self {
+            n,
+            data: data.into_boxed_slice(),
+        }
     }
 
-    /// Returns the (D0, R0^2) parameters for the given pair of atom types.
+    /// Returns the [`LjPair`] parameters for the given atom types.
     #[inline(always)]
-    pub fn get(&self, i: TypeIdx, j: TypeIdx) -> (f32, f32) {
+    pub fn get(&self, i: TypeIdx, j: TypeIdx) -> LjPair {
+        self.data[usize::from(i) * self.n + usize::from(j)]
+    }
+}
+
+/// Flat symmetric n×n matrix of pre-computed [`BuckPair`] parameters.
+#[derive(Debug, Clone)]
+pub struct BuckMatrix {
+    /// Number of atom types (matrix dimension).
+    n: usize,
+    /// Flat array of length n*n.
+    data: Box<[BuckPair]>,
+}
+
+impl BuckMatrix {
+    /// Creates a Buckingham parameter matrix of dimension `n × n`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `data.len() ≠ n * n`.
+    pub fn new(n: usize, data: Vec<BuckPair>) -> Self {
+        assert_eq!(data.len(), n * n, "data.len() must equal n*n");
+        Self {
+            n,
+            data: data.into_boxed_slice(),
+        }
+    }
+
+    /// Returns the [`BuckPair`] parameters for the given atom types.
+    #[inline(always)]
+    pub fn get(&self, i: TypeIdx, j: TypeIdx) -> BuckPair {
         self.data[usize::from(i) * self.n + usize::from(j)]
     }
 }
@@ -271,12 +337,43 @@ mod tests {
         .unwrap()
     }
 
-    fn identity_vdw(n: usize) -> VdwMatrix {
-        let mut data = vec![(0.0f32, 0.0f32); n * n];
+    fn lj_identity(n: usize) -> LjMatrix {
+        let mut data = vec![
+            LjPair {
+                d0: 0.0,
+                r0_sq: 0.0
+            };
+            n * n
+        ];
         for i in 0..n {
-            data[i * n + i] = (1.0, 4.0);
+            data[i * n + i] = LjPair {
+                d0: 1.0,
+                r0_sq: 4.0,
+            };
         }
-        VdwMatrix::new(n, data)
+        LjMatrix::new(n, data)
+    }
+
+    fn buck_identity(n: usize) -> BuckMatrix {
+        let zero = BuckPair {
+            a: 0.0,
+            b: 0.0,
+            c: 0.0,
+            r_max_sq: 0.0,
+            two_e_max: 0.0,
+        };
+        let diag = BuckPair {
+            a: 1.0,
+            b: 0.5,
+            c: 2.0,
+            r_max_sq: 4.0,
+            two_e_max: 0.1,
+        };
+        let mut data = vec![zero; n * n];
+        for i in 0..n {
+            data[i * n + i] = diag;
+        }
+        BuckMatrix::new(n, data)
     }
 
     fn empty_hbond() -> HBondParams {
@@ -340,27 +437,91 @@ mod tests {
     }
 
     #[test]
-    fn vdw_matrix_diagonal_lookup() {
-        let m = identity_vdw(4);
-        assert_eq!(m.get(t(0), t(0)), (1.0, 4.0));
-        assert_eq!(m.get(t(1), t(1)), (1.0, 4.0));
+    fn lj_matrix_diagonal_lookup() {
+        let m = lj_identity(4);
+        assert_eq!(
+            m.get(t(0), t(0)),
+            LjPair {
+                d0: 1.0,
+                r0_sq: 4.0
+            }
+        );
+        assert_eq!(
+            m.get(t(3), t(3)),
+            LjPair {
+                d0: 1.0,
+                r0_sq: 4.0
+            }
+        );
     }
 
     #[test]
-    fn vdw_matrix_off_diagonal_zero() {
-        let m = identity_vdw(4);
-        assert_eq!(m.get(t(0), t(1)), (0.0, 0.0));
-        assert_eq!(m.get(t(2), t(3)), (0.0, 0.0));
+    fn lj_matrix_off_diagonal_zero() {
+        let m = lj_identity(4);
+        assert_eq!(
+            m.get(t(0), t(1)),
+            LjPair {
+                d0: 0.0,
+                r0_sq: 0.0
+            }
+        );
+        assert_eq!(
+            m.get(t(2), t(3)),
+            LjPair {
+                d0: 0.0,
+                r0_sq: 0.0
+            }
+        );
     }
 
     #[test]
-    fn vdw_matrix_symmetric_fill() {
+    fn lj_matrix_symmetric_fill() {
         let n = 3usize;
-        let mut data = vec![(0.0f32, 0.0f32); n * n];
-        data[0 * n + 1] = (2.0, 8.0);
-        data[1 * n + 0] = (2.0, 8.0);
-        let m = VdwMatrix::new(n, data);
+        let mut data = vec![
+            LjPair {
+                d0: 0.0,
+                r0_sq: 0.0
+            };
+            n * n
+        ];
+        data[0 * n + 1] = LjPair {
+            d0: 2.0,
+            r0_sq: 8.0,
+        };
+        data[1 * n + 0] = LjPair {
+            d0: 2.0,
+            r0_sq: 8.0,
+        };
+        let m = LjMatrix::new(n, data);
         assert_eq!(m.get(t(0), t(1)), m.get(t(1), t(0)));
+    }
+
+    #[test]
+    fn buck_matrix_diagonal_lookup() {
+        let m = buck_identity(4);
+        let diag = BuckPair {
+            a: 1.0,
+            b: 0.5,
+            c: 2.0,
+            r_max_sq: 4.0,
+            two_e_max: 0.1,
+        };
+        assert_eq!(m.get(t(0), t(0)), diag);
+        assert_eq!(m.get(t(3), t(3)), diag);
+    }
+
+    #[test]
+    fn buck_matrix_off_diagonal_zero() {
+        let m = buck_identity(4);
+        let zero = BuckPair {
+            a: 0.0,
+            b: 0.0,
+            c: 0.0,
+            r_max_sq: 0.0,
+            two_e_max: 0.0,
+        };
+        assert_eq!(m.get(t(0), t(1)), zero);
+        assert_eq!(m.get(t(2), t(3)), zero);
     }
 
     #[test]
@@ -407,7 +568,7 @@ mod tests {
                 donor_for_h: vec![],
             },
             ff: ForceFieldParams {
-                vdw: identity_vdw(4),
+                vdw: VdwMatrix::LennardJones(lj_identity(4)),
                 hbond: empty_hbond(),
             },
         };
@@ -520,8 +681,30 @@ mod tests {
 
     #[test]
     #[should_panic]
-    fn vdw_matrix_new_panics_on_wrong_data_length() {
-        VdwMatrix::new(3, vec![(1.0f32, 1.0f32); 8]);
+    fn lj_matrix_new_panics_on_wrong_data_length() {
+        LjMatrix::new(
+            3,
+            vec![
+                LjPair {
+                    d0: 1.0,
+                    r0_sq: 1.0
+                };
+                8
+            ],
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn buck_matrix_new_panics_on_wrong_data_length() {
+        let p = BuckPair {
+            a: 0.0,
+            b: 0.0,
+            c: 0.0,
+            r_max_sq: 0.0,
+            two_e_max: 0.0,
+        };
+        BuckMatrix::new(3, vec![p; 8]);
     }
 
     #[test]

--- a/src/model/system.rs
+++ b/src/model/system.rs
@@ -212,9 +212,13 @@ impl LjMatrix {
     ///
     /// # Panics
     ///
-    /// Panics if `data.len() ≠ n * n`.
+    /// Panics if `data.len() ≠ n * n`, or if the matrix is not symmetric.
     pub fn new(n: usize, data: Vec<LjPair>) -> Self {
         assert_eq!(data.len(), n * n, "data.len() must equal n*n");
+        assert!(
+            (0..n).all(|i| (0..i).all(|j| data[i * n + j] == data[j * n + i])),
+            "matrix must be symmetric"
+        );
         Self {
             n,
             data: data.into_boxed_slice(),
@@ -242,9 +246,13 @@ impl BuckMatrix {
     ///
     /// # Panics
     ///
-    /// Panics if `data.len() ≠ n * n`.
+    /// Panics if `data.len() ≠ n * n`, or if the matrix is not symmetric.
     pub fn new(n: usize, data: Vec<BuckPair>) -> Self {
         assert_eq!(data.len(), n * n, "data.len() must equal n*n");
+        assert!(
+            (0..n).all(|i| (0..i).all(|j| data[i * n + j] == data[j * n + i])),
+            "matrix must be symmetric"
+        );
         Self {
             n,
             data: data.into_boxed_slice(),
@@ -525,6 +533,30 @@ mod tests {
     }
 
     #[test]
+    fn buck_matrix_symmetric_fill() {
+        let n = 3usize;
+        let pair = BuckPair {
+            a: 1.0,
+            b: 0.5,
+            c: 2.0,
+            r_max_sq: 4.0,
+            two_e_max: 0.1,
+        };
+        let zero = BuckPair {
+            a: 0.0,
+            b: 0.0,
+            c: 0.0,
+            r_max_sq: 0.0,
+            two_e_max: 0.0,
+        };
+        let mut data = vec![zero; n * n];
+        data[0 * n + 1] = pair;
+        data[1 * n + 0] = pair;
+        let m = BuckMatrix::new(n, data);
+        assert_eq!(m.get(t(0), t(1)), m.get(t(1), t(0)));
+    }
+
+    #[test]
     fn hbond_candidate_both_directions() {
         let mut h_types = HashSet::new();
         let mut acc_types = HashSet::new();
@@ -696,6 +728,21 @@ mod tests {
 
     #[test]
     #[should_panic]
+    fn lj_matrix_new_panics_on_asymmetric() {
+        let zero = LjPair {
+            d0: 0.0,
+            r0_sq: 0.0,
+        };
+        let mut data = vec![zero; 4];
+        data[0 * 2 + 1] = LjPair {
+            d0: 1.0,
+            r0_sq: 1.0,
+        };
+        LjMatrix::new(2, data);
+    }
+
+    #[test]
+    #[should_panic]
     fn buck_matrix_new_panics_on_wrong_data_length() {
         let p = BuckPair {
             a: 0.0,
@@ -705,6 +752,27 @@ mod tests {
             two_e_max: 0.0,
         };
         BuckMatrix::new(3, vec![p; 8]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn buck_matrix_new_panics_on_asymmetric() {
+        let zero = BuckPair {
+            a: 0.0,
+            b: 0.0,
+            c: 0.0,
+            r_max_sq: 0.0,
+            two_e_max: 0.0,
+        };
+        let mut data = vec![zero; 4];
+        data[0 * 2 + 1] = BuckPair {
+            a: 1.0,
+            b: 0.5,
+            c: 2.0,
+            r_max_sq: 4.0,
+            two_e_max: 0.1,
+        };
+        BuckMatrix::new(2, data);
     }
 
     #[test]

--- a/src/model/types.rs
+++ b/src/model/types.rs
@@ -55,7 +55,7 @@ impl Vec3 {
         self.len_sq().sqrt()
     }
 
-    /// Returns the unit vector in the same direction. Behaviour is unspecified for
+    /// Returns the unit vector in the same direction. Behavior is unspecified for
     /// zero-length vectors.
     #[inline(always)]
     pub fn normalize(self) -> Vec3 {

--- a/src/pack/model/graph.rs
+++ b/src/pack/model/graph.rs
@@ -11,7 +11,7 @@ pub struct ContactGraph {
 impl ContactGraph {
     /// Constructs a contact graph from raw pairwise contacts.
     ///
-    /// Self-loops are silently dropped. Each pair is canonicalised so the
+    /// Self-loops are silently dropped. Each pair is canonicalized so the
     /// smaller index comes first; duplicates and reversed copies are removed.
     ///
     /// # Panics


### PR DESCRIPTION
### Summary:

Established the `io` module for PDB/mmCIF structure processing and `Session` state management via `dreid-forge` integration. This includes comprehensive configuration pipelines (cleaning, protonation, parameterization) and a major refactor of VdW parameter matrices for strict type safety.

### Changes:

- **IO Pipeline:** Implemented `read` and `write` functions (`convert.rs`) to parse/serialize PDB and mmCIF formats, delegating topology and force-field parameterization to `dreid-forge`.
- **Configuration Models:** Added robust configuration structs (`ReadConfig`, `ProtonationConfig`, `ChargeConfig`, `QeqConfig`) covering atom cleaning, His-tautomer selection, and hybrid QEq charge schemes.
- **Session State:** Created `Session` and `SystemMetadata` models (`session.rs`) to partition atoms into `FixedAtom` and `MobileSidechain` components with precise `AtomRef` bookkeeping.
- **Atom Ordering:** Added canonical sidechain atom ordering rules (`order.rs`) for 29 standard residue types to ensure consistent coordinate mapping.
- **VdW Matrix Refactor:** Upgraded `VdwMatrix` from flat tuples to a strongly-typed enum (`LennardJones(LjMatrix)`, `Buckingham(BuckMatrix)`) with strict matrix symmetry and dimension validation.
- **Error Handling:** Centralized IO, parsing, and template error mapping in `error.rs`.