### PR TITLE
perf(pack): Improve Intra-Structure Parallel Efficiency

### DIFF
--- a/crates/dreid-pack/src/pack/model/energy.rs
+++ b/crates/dreid-pack/src/pack/model/energy.rs
@@ -114,14 +114,6 @@ impl PairEnergyTable {
         (self.sizes[edge].0 as usize, self.sizes[edge].1 as usize)
     }
 
-    /// Sets pair energy for candidates `ri`, `rj` on `edge`.
-    pub fn set(&mut self, edge: usize, ri: usize, rj: usize, val: f32) {
-        let (ni, nj) = self.dims(edge);
-        debug_assert!(ri < ni, "ri {ri} out of bounds (n_i={ni})");
-        debug_assert!(rj < nj, "rj {rj} out of bounds (n_j={nj})");
-        self.data[self.offsets[edge] + ri * nj + rj] = val;
-    }
-
     /// Raw sub-matrix slice for `edge` (row-major, length = Ri × Rj).
     pub fn matrix(&self, edge: usize) -> &[f32] {
         debug_assert!(
@@ -130,6 +122,19 @@ impl PairEnergyTable {
             self.n_edges(),
         );
         &self.data[self.offsets[edge]..self.offsets[edge + 1]]
+    }
+
+    /// Returns non-overlapping mutable slices for all edges.
+    pub fn matrices_mut(&mut self) -> Vec<&mut [f32]> {
+        let mut slices = Vec::with_capacity(self.sizes.len());
+        let mut rest = self.data.as_mut_slice();
+        for e in 0..self.sizes.len() {
+            let len = self.offsets[e + 1] - self.offsets[e];
+            let (head, tail) = rest.split_at_mut(len);
+            slices.push(head);
+            rest = tail;
+        }
+        slices
     }
 }
 
@@ -284,22 +289,6 @@ mod tests {
     }
 
     #[test]
-    fn pair_set_then_get_round_trips() {
-        let mut t = PairEnergyTable::new(&[(3, 4)]);
-        t.set(0, 2, 3, -1.5);
-        let nj = t.dims(0).1;
-        assert_eq!(t.matrix(0)[2 * nj + 3], -1.5);
-    }
-
-    #[test]
-    fn pair_edges_are_independent() {
-        let mut t = PairEnergyTable::new(&[(2, 2), (2, 2)]);
-        t.set(0, 1, 0, 7.0);
-        let nj = t.dims(1).1;
-        assert_eq!(t.matrix(1)[nj + 0], 0.0);
-    }
-
-    #[test]
     fn pair_matrix_length_matches_product() {
         let t = PairEnergyTable::new(&[(3, 4), (2, 5)]);
         assert_eq!(t.matrix(0).len(), 12);
@@ -307,36 +296,61 @@ mod tests {
     }
 
     #[test]
-    fn pair_matrix_reflects_set_calls() {
+    fn pair_matrices_mut_empty_returns_empty() {
+        let mut t = PairEnergyTable::new(&[]);
+        assert!(t.matrices_mut().is_empty());
+    }
+
+    #[test]
+    fn pair_matrices_mut_count_matches_edges() {
+        let mut t = PairEnergyTable::new(&[(2, 3), (4, 1), (1, 5)]);
+        assert_eq!(t.matrices_mut().len(), 3);
+    }
+
+    #[test]
+    fn pair_matrices_mut_slice_lengths_match_dims() {
+        let mut t = PairEnergyTable::new(&[(3, 4), (2, 5)]);
+        let slices = t.matrices_mut();
+        assert_eq!(slices[0].len(), 12);
+        assert_eq!(slices[1].len(), 10);
+    }
+
+    #[test]
+    fn pair_matrices_mut_written_data_visible_via_matrix() {
         let mut t = PairEnergyTable::new(&[(2, 3)]);
-        t.set(0, 0, 0, 1.0);
-        t.set(0, 0, 2, 3.0);
-        t.set(0, 1, 1, 5.0);
+        {
+            let mut slices = t.matrices_mut();
+            slices[0][0 * 3 + 0] = 1.0;
+            slices[0][0 * 3 + 2] = 3.0;
+            slices[0][1 * 3 + 1] = 5.0;
+        }
         assert_eq!(t.matrix(0), &[1.0, 0.0, 3.0, 0.0, 5.0, 0.0]);
     }
 
     #[test]
-    #[cfg(debug_assertions)]
-    #[should_panic]
-    fn pair_set_panics_edge_out_of_bounds() {
-        let mut t = PairEnergyTable::new(&[(2, 3)]);
-        t.set(1, 0, 0, 0.0);
+    fn pair_matrices_mut_edges_are_independent() {
+        let mut t = PairEnergyTable::new(&[(2, 2), (2, 2)]);
+        {
+            let mut slices = t.matrices_mut();
+            slices[0][1 * 2 + 0] = 7.0;
+        }
+        assert_eq!(t.matrix(1)[1 * 2 + 0], 0.0);
     }
 
     #[test]
     #[cfg(debug_assertions)]
     #[should_panic]
-    fn pair_set_panics_ri_out_of_bounds() {
-        let mut t = PairEnergyTable::new(&[(2, 3)]);
-        t.set(0, 2, 0, 0.0);
+    fn pair_dims_panics_edge_out_of_bounds() {
+        let t = PairEnergyTable::new(&[(2, 3)]);
+        let _ = t.dims(1);
     }
 
     #[test]
     #[cfg(debug_assertions)]
     #[should_panic]
-    fn pair_set_panics_rj_out_of_bounds() {
-        let mut t = PairEnergyTable::new(&[(2, 3)]);
-        t.set(0, 0, 3, 0.0);
+    fn pair_matrix_panics_edge_out_of_bounds() {
+        let t = PairEnergyTable::new(&[(2, 3)]);
+        let _ = t.matrix(1);
     }
 
     #[test]

--- a/crates/dreid-pack/src/pack/model/spatial.rs
+++ b/crates/dreid-pack/src/pack/model/spatial.rs
@@ -111,7 +111,7 @@ impl<T: Copy> SpatialGrid<T> {
                 unsafe { (sorted_ptr as *mut (Vec3, T)).add(slot).write((*pos, *val)) };
             }
         });
-        // SAFETY: every element has been initialised by the parallel loop above.
+        // SAFETY: every element has been initialized by the parallel loop above.
         let sorted = unsafe {
             std::vec::Vec::from_raw_parts(
                 sorted_uninit.as_mut_ptr() as *mut (Vec3, T),

--- a/crates/dreid-pack/src/pack/phase/dee.rs
+++ b/crates/dreid-pack/src/pack/phase/dee.rs
@@ -1,8 +1,11 @@
 use crate::pack::model::{
-    energy::{PRUNED, PairEnergyTable, SelfEnergyTable},
+    energy::{PairEnergyTable, SelfEnergyTable},
     graph::ContactGraph,
 };
 use rayon::prelude::*;
+
+/// Minimum chunk length for parallel dispatch.
+const MIN_PAR_LEN: usize = 32;
 
 /// Runs Dead-End Elimination on the energy tables, pruning rotamers that
 /// provably cannot appear in the Global Minimum Energy Conformation. Returns
@@ -13,8 +16,7 @@ pub fn dee(self_e: &mut SelfEnergyTable, pair_e: &PairEnergyTable, graph: &Conta
     debug_assert_eq!(graph.n_edges(), pair_e.n_edges());
 
     let mut fixed = vec![false; n];
-
-    let mut total_eliminated = 0usize;
+    let mut total = 0;
 
     for phase in [
         Phase::Goldstein,
@@ -22,21 +24,110 @@ pub fn dee(self_e: &mut SelfEnergyTable, pair_e: &PairEnergyTable, graph: &Conta
         Phase::Goldstein,
         Phase::Split,
     ] {
-        total_eliminated += converge(phase, self_e, pair_e, graph, &fixed);
+        total += converge(phase, self_e, pair_e, graph, &fixed);
         absorb(self_e, pair_e, graph, &mut fixed);
     }
 
-    total_eliminated
+    total
 }
 
-/// DEE Phase: Goldstein or Split.
+/// DEE phase selector.
 #[derive(Clone, Copy)]
 enum Phase {
     Goldstein,
     Split,
 }
 
-/// Runs the given DEE phase in rounds until no more eliminations occur.
+/// Precomputed edge to a non-fixed neighbor slot, carrying a reference into
+/// the pair-energy matrix and the index-layout flag.
+struct Edge<'a> {
+    slot: usize,
+    mat: &'a [f32],
+    stride: usize,
+    is_left: bool,
+}
+
+impl Edge<'_> {
+    /// Pair-energy value for candidate `ci` at the source slot and `cj` here.
+    fn pair_val(&self, ci: usize, cj: usize) -> f32 {
+        if self.is_left {
+            self.mat[ci * self.stride + cj]
+        } else {
+            self.mat[cj * self.stride + ci]
+        }
+    }
+
+    /// Tightest pair-energy gap between `s` and `r` over living candidates.
+    fn min_diff(&self, s: usize, r: usize, alive: &[u16]) -> f32 {
+        if self.is_left {
+            let off_s = s * self.stride;
+            let off_r = r * self.stride;
+            let mut m = f32::INFINITY;
+            for &t in alive {
+                let d = self.mat[off_s + t as usize] - self.mat[off_r + t as usize];
+                if d < m {
+                    m = d;
+                }
+            }
+            m
+        } else {
+            let mut m = f32::INFINITY;
+            for &t in alive {
+                let off = t as usize * self.stride;
+                let d = self.mat[off + s] - self.mat[off + r];
+                if d < m {
+                    m = d;
+                }
+            }
+            m
+        }
+    }
+}
+
+/// Collects alive candidate indices per slot, sorted by ascending self-energy.
+fn build_alive(self_e: &SelfEnergyTable) -> Vec<Vec<u16>> {
+    (0..self_e.n_slots())
+        .map(|s| {
+            let mut v: Vec<u16> = (0..self_e.n_candidates(s) as u16)
+                .filter(|&r| !self_e.is_pruned(s, r as usize))
+                .collect();
+            v.sort_unstable_by(|&a, &b| {
+                self_e
+                    .get(s, a as usize)
+                    .total_cmp(&self_e.get(s, b as usize))
+            });
+            v
+        })
+        .collect()
+}
+
+/// Collects precomputed [`Edge`] info per slot, skipping fixed neighbors.
+fn build_edges<'a>(
+    n: usize,
+    pair_e: &'a PairEnergyTable,
+    graph: &ContactGraph,
+    fixed: &[bool],
+) -> Vec<Vec<Edge<'a>>> {
+    (0..n)
+        .map(|i| {
+            graph
+                .neighbor_edges(i)
+                .filter(|&(j, _, _)| !fixed[j as usize])
+                .map(|(j, e, is_left)| {
+                    let e = e as usize;
+                    Edge {
+                        slot: j as usize,
+                        mat: pair_e.matrix(e),
+                        stride: pair_e.dims(e).1,
+                        is_left,
+                    }
+                })
+                .collect()
+        })
+        .collect()
+}
+
+/// Runs the given DEE phase in rounds until convergence.
 fn converge(
     phase: Phase,
     self_e: &mut SelfEnergyTable,
@@ -45,120 +136,94 @@ fn converge(
     fixed: &[bool],
 ) -> usize {
     let n = self_e.n_slots();
-    let mut total = 0usize;
+    let mut alive = build_alive(self_e);
+    let edges = build_edges(n, pair_e, graph, fixed);
+
+    let mut dirty: Vec<bool> = (0..n).map(|i| !fixed[i] && alive[i].len() >= 2).collect();
+    let mut total = 0;
 
     loop {
-        let elims: Vec<Vec<usize>> = (0..n)
-            .into_par_iter()
-            .map(|i| {
-                if fixed[i] || !has_choice(self_e, i) {
-                    return Vec::new();
-                }
-                match phase {
-                    Phase::Goldstein => goldstein_slot(i, self_e, pair_e, graph, fixed),
-                    Phase::Split => split_slot(i, self_e, pair_e, graph, fixed),
-                }
-            })
+        let work: Vec<usize> = dirty
+            .iter()
+            .enumerate()
+            .filter_map(|(i, &d)| d.then_some(i))
             .collect();
-
-        let mut round_eliminated = 0usize;
-        for (i, dead) in elims.into_iter().enumerate() {
-            round_eliminated += dead.len();
-            for s in dead {
-                self_e.prune(i, s);
-            }
-        }
-
-        if round_eliminated == 0 {
+        if work.is_empty() {
             break;
         }
-        total += round_eliminated;
+        for &i in &work {
+            dirty[i] = false;
+        }
+
+        let eliminate = |&i: &usize| -> Option<(usize, Vec<usize>)> {
+            if alive[i].len() < 2 {
+                return None;
+            }
+            let dead = match phase {
+                Phase::Goldstein => goldstein(i, self_e, &edges[i], &alive),
+                Phase::Split => split(i, self_e, &edges[i], &alive),
+            };
+            if dead.is_empty() {
+                None
+            } else {
+                Some((i, dead))
+            }
+        };
+
+        let elims: Vec<(usize, Vec<usize>)> = work
+            .par_iter()
+            .with_min_len(MIN_PAR_LEN)
+            .filter_map(eliminate)
+            .collect();
+        if elims.is_empty() {
+            break;
+        }
+
+        for (i, dead) in &elims {
+            total += dead.len();
+            for &r in dead {
+                self_e.prune(*i, r);
+            }
+            alive[*i].retain(|&r| !dead.contains(&(r as usize)));
+            for edge in &edges[*i] {
+                if alive[edge.slot].len() >= 2 {
+                    dirty[edge.slot] = true;
+                }
+            }
+        }
     }
 
     total
 }
 
-/// Returns `true` if slot `s` has at least two non-pruned candidates.
-fn has_choice(self_e: &SelfEnergyTable, s: usize) -> bool {
-    let mut seen = 0u8;
-    for r in 0..self_e.n_candidates(s) {
-        if !self_e.is_pruned(s, r) {
-            seen += 1;
-            if seen >= 2 {
-                return true;
-            }
-        }
-    }
-    false
-}
-
-/// Pair-energy lookup for `(ci_at_slot_i, cj_at_neighbor)` on `edge`.
-fn pair_val(mat: &[f32], stride: usize, is_left: bool, ci: usize, cj: usize) -> f32 {
-    if is_left {
-        mat[ci * stride + cj]
-    } else {
-        mat[cj * stride + ci]
-    }
-}
-
-/// Applies the Goldstein criterion to every surviving candidate at slot `i`.
-fn goldstein_slot(
+/// Goldstein DEE: candidate `s` at slot `i` is dead if any single witness `r`
+/// dominates it across all neighbor interactions.
+fn goldstein(
     i: usize,
     self_e: &SelfEnergyTable,
-    pair_e: &PairEnergyTable,
-    graph: &ContactGraph,
-    fixed: &[bool],
+    edges: &[Edge<'_>],
+    alive: &[Vec<u16>],
 ) -> Vec<usize> {
-    let nc = self_e.n_candidates(i);
+    let alive_i = &alive[i];
     let mut dead = Vec::new();
 
-    let edges: Vec<(usize, &[f32], usize, bool)> = graph
-        .neighbor_edges(i)
-        .filter(|&(j, _, _)| !fixed[j as usize])
-        .map(|(j, e, is_left)| {
-            let e = e as usize;
-            let mat = pair_e.matrix(e);
-            let stride = pair_e.dims(e).1;
-            (j as usize, mat, stride, is_left)
-        })
-        .collect();
-
-    for s in 0..nc {
-        if self_e.is_pruned(i, s) {
-            continue;
-        }
-
+    for &s in alive_i {
+        let s = s as usize;
         let es = self_e.get(i, s);
 
-        let is_dead = (0..nc).any(|r| {
-            if r == s || self_e.is_pruned(i, r) {
+        let dominated = alive_i.iter().any(|&r| {
+            let r = r as usize;
+            if r == s {
                 return false;
             }
-
-            let mut ex = es - self_e.get(i, r);
-
-            for &(j, mat, stride, is_left) in &edges {
-                let nc_j = self_e.n_candidates(j);
-
-                let mut min_diff = PRUNED;
-                for t in 0..nc_j {
-                    if self_e.is_pruned(j, t) {
-                        continue;
-                    }
-                    let diff =
-                        pair_val(mat, stride, is_left, s, t) - pair_val(mat, stride, is_left, r, t);
-                    if diff < min_diff {
-                        min_diff = diff;
-                    }
-                }
-
-                ex += min_diff;
+            let mut excess = es - self_e.get(i, r);
+            for edge in edges {
+                excess += edge.min_diff(s, r, &alive[edge.slot]);
             }
-
-            ex > 0.0
+            excess > 0.0
         });
 
-        if is_dead {
+        if dominated {
             dead.push(s);
         }
     }
@@ -166,102 +231,63 @@ fn goldstein_slot(
     dead
 }
 
-/// Applies the Split DEE criterion to every surviving candidate at slot `i`.
-fn split_slot(
-    i: usize,
-    self_e: &SelfEnergyTable,
-    pair_e: &PairEnergyTable,
-    graph: &ContactGraph,
-    fixed: &[bool],
-) -> Vec<usize> {
-    let nc = self_e.n_candidates(i);
-    let mut dead = Vec::new();
-
-    let neighbors: Vec<(usize, &[f32], usize, bool)> = graph
-        .neighbor_edges(i)
-        .filter(|&(j, _, _)| !fixed[j as usize])
-        .map(|(j, e, is_left)| {
-            let e = e as usize;
-            let mat = pair_e.matrix(e);
-            let stride = pair_e.dims(e).1;
-            (j as usize, mat, stride, is_left)
-        })
-        .collect();
-
-    let n_nbr = neighbors.len();
+/// Split DEE: candidate `s` at slot `i` is dead if, for some neighbor `k`,
+/// every candidate `vk` at `k` is dominated by some witness `r`.
+fn split(i: usize, self_e: &SelfEnergyTable, edges: &[Edge<'_>], alive: &[Vec<u16>]) -> Vec<usize> {
+    let alive_i = &alive[i];
+    let n_nbr = edges.len();
     if n_nbr == 0 {
-        return dead;
+        return Vec::new();
     }
 
-    let max_comp = nc.saturating_sub(1);
-    let mut comp_buf = Vec::with_capacity(max_comp);
-    let mut diff_self_buf = Vec::with_capacity(max_comp);
-    let mut min_pair_buf = vec![0.0f32; max_comp * n_nbr];
-    let mut sum_all_buf = Vec::with_capacity(max_comp);
+    let max_wit = alive_i.len().saturating_sub(1);
+    let mut witnesses: Vec<usize> = Vec::with_capacity(max_wit);
+    let mut self_diffs = Vec::with_capacity(max_wit);
+    let mut pair_diffs = vec![0.0f32; max_wit * n_nbr];
+    let mut totals = Vec::with_capacity(max_wit);
+    let mut dead = Vec::new();
 
-    for s in 0..nc {
-        if self_e.is_pruned(i, s) {
-            continue;
-        }
+    for &s in alive_i {
+        let s = s as usize;
         let es = self_e.get(i, s);
 
-        comp_buf.clear();
-        diff_self_buf.clear();
-        for r in 0..nc {
-            if r == s || self_e.is_pruned(i, r) {
+        witnesses.clear();
+        self_diffs.clear();
+        for &r in alive_i {
+            let r = r as usize;
+            if r == s {
                 continue;
             }
-            diff_self_buf.push(es - self_e.get(i, r));
-            comp_buf.push(r);
+            self_diffs.push(es - self_e.get(i, r));
+            witnesses.push(r);
         }
-        let n_comp = comp_buf.len();
-        if n_comp == 0 {
+        let n_wit = witnesses.len();
+        if n_wit == 0 {
             continue;
         }
 
-        for (ci, &r) in comp_buf.iter().enumerate() {
-            for (ki, &(j, mat, stride, is_left)) in neighbors.iter().enumerate() {
-                let nc_j = self_e.n_candidates(j);
-                let mut min_v = PRUNED;
-                for t in 0..nc_j {
-                    if self_e.is_pruned(j, t) {
-                        continue;
-                    }
-                    let diff =
-                        pair_val(mat, stride, is_left, s, t) - pair_val(mat, stride, is_left, r, t);
-                    if diff < min_v {
-                        min_v = diff;
-                    }
-                }
-                min_pair_buf[ci * n_nbr + ki] = min_v;
+        for (wi, &r) in witnesses.iter().enumerate() {
+            for (ki, edge) in edges.iter().enumerate() {
+                pair_diffs[wi * n_nbr + ki] = edge.min_diff(s, r, &alive[edge.slot]);
             }
         }
 
-        sum_all_buf.clear();
-        for ci in 0..n_comp {
-            let row = &min_pair_buf[ci * n_nbr..(ci + 1) * n_nbr];
-            sum_all_buf.push(diff_self_buf[ci] + row.iter().sum::<f32>());
+        totals.clear();
+        for wi in 0..n_wit {
+            let row = &pair_diffs[wi * n_nbr..(wi + 1) * n_nbr];
+            totals.push(self_diffs[wi] + row.iter().sum::<f32>());
         }
 
-        let mut pruned = false;
-
-        'split_k: for (ki, &(k, mat_k, stride_k, is_left_k)) in neighbors.iter().enumerate() {
-            let nc_k = self_e.n_candidates(k);
-
-            let all_vk_eliminated = (0..nc_k).filter(|&vk| !self_e.is_pruned(k, vk)).all(|vk| {
-                (0..n_comp).any(|ci| {
-                    let ex = sum_all_buf[ci] - min_pair_buf[ci * n_nbr + ki]
-                        + pair_val(mat_k, stride_k, is_left_k, s, vk)
-                        - pair_val(mat_k, stride_k, is_left_k, comp_buf[ci], vk);
-                    ex > 0.0
+        let pruned = edges.iter().enumerate().any(|(ki, edge)| {
+            alive[edge.slot].iter().all(|&vk| {
+                let vk = vk as usize;
+                (0..n_wit).any(|wi| {
+                    totals[wi] - pair_diffs[wi * n_nbr + ki] + edge.pair_val(s, vk)
+                        - edge.pair_val(witnesses[wi], vk)
+                        > 0.0
                 })
-            });
-
-            if all_vk_eliminated {
-                pruned = true;
-                break 'split_k;
-            }
-        }
+            })
+        });
 
         if pruned {
             dead.push(s);
@@ -271,17 +297,15 @@ fn split_slot(
     dead
 }
 
-/// Fixes every slot that has exactly one surviving candidate and absorbs
-/// its pair-energy contribution into the self-energy of its neighbors.
+/// Fixes every slot that has exactly one surviving candidate and folds its
+/// pair-energy contribution into the self-energy of each neighbor.
 fn absorb(
     self_e: &mut SelfEnergyTable,
     pair_e: &PairEnergyTable,
     graph: &ContactGraph,
     fixed: &mut [bool],
 ) {
-    let n = self_e.n_slots();
-
-    let newly_fixed: Vec<(usize, usize)> = (0..n)
+    let newly_fixed: Vec<(usize, usize)> = (0..self_e.n_slots())
         .filter_map(|s| {
             if fixed[s] {
                 return None;
@@ -290,7 +314,7 @@ fn absorb(
             for r in 0..self_e.n_candidates(s) {
                 if !self_e.is_pruned(s, r) {
                     if sole.is_some() {
-                        return None; // more than one survivor
+                        return None;
                     }
                     sole = Some(r);
                 }
@@ -303,25 +327,27 @@ fn absorb(
         return;
     }
 
-    for &(fi, best_rot) in &newly_fixed {
-        for (j, edge, is_left) in graph.neighbor_edges(fi) {
+    for &(fi, sole_rot) in &newly_fixed {
+        for (j, e, is_left) in graph.neighbor_edges(fi) {
             let j = j as usize;
             if fixed[j] {
                 continue;
             }
-            let edge = edge as usize;
-            let mat = pair_e.matrix(edge);
-            let stride = pair_e.dims(edge).1;
+            let e = e as usize;
+            let mat = pair_e.matrix(e);
+            let stride = pair_e.dims(e).1;
 
-            let nc_j = self_e.n_candidates(j);
-            for rj in 0..nc_j {
+            for rj in 0..self_e.n_candidates(j) {
                 if self_e.is_pruned(j, rj) {
                     continue;
                 }
-                let pv = pair_val(mat, stride, is_left, best_rot, rj);
+                let pv = if is_left {
+                    mat[sole_rot * stride + rj]
+                } else {
+                    mat[rj * stride + sole_rot]
+                };
                 if pv != 0.0 {
-                    let v = self_e.get(j, rj);
-                    self_e.set(j, rj, v + pv);
+                    self_e.set(j, rj, self_e.get(j, rj) + pv);
                 }
             }
         }
@@ -335,6 +361,7 @@ fn absorb(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::pack::model::energy::PRUNED;
 
     fn two_slot(
         counts: [u16; 2],
@@ -348,93 +375,108 @@ mod tests {
         (self_e, pair_e, graph)
     }
 
-    fn alive(self_e: &SelfEnergyTable, s: usize) -> Vec<usize> {
+    fn alive_at(self_e: &SelfEnergyTable, s: usize) -> Vec<usize> {
         (0..self_e.n_candidates(s))
             .filter(|&r| !self_e.is_pruned(s, r))
             .collect()
     }
 
+    fn run_goldstein(
+        i: usize,
+        self_e: &SelfEnergyTable,
+        pair_e: &PairEnergyTable,
+        graph: &ContactGraph,
+        fixed: &[bool],
+    ) -> Vec<usize> {
+        let alive = build_alive(self_e);
+        let edges = build_edges(self_e.n_slots(), pair_e, graph, fixed);
+        goldstein(i, self_e, &edges[i], &alive)
+    }
+
+    fn run_split(
+        i: usize,
+        self_e: &SelfEnergyTable,
+        pair_e: &PairEnergyTable,
+        graph: &ContactGraph,
+        fixed: &[bool],
+    ) -> Vec<usize> {
+        let alive = build_alive(self_e);
+        let edges = build_edges(self_e.n_slots(), pair_e, graph, fixed);
+        split(i, self_e, &edges[i], &alive)
+    }
+
     #[test]
-    fn goldstein_no_neighbors_eliminates_locally_dominated_candidate() {
+    fn goldstein_eliminates_dominated_candidates() {
         let mut self_e = SelfEnergyTable::new(&[3]);
         self_e.set(0, 0, 5.0);
         self_e.set(0, 1, 2.0);
         self_e.set(0, 2, 3.0);
         let pair_e = PairEnergyTable::new(&[]);
         let graph = ContactGraph::build(1, std::iter::empty::<(u32, u32)>());
-        let fixed = vec![false];
 
-        let mut dead = goldstein_slot(0, &self_e, &pair_e, &graph, &fixed);
+        let mut dead = run_goldstein(0, &self_e, &pair_e, &graph, &[false]);
         dead.sort_unstable();
         assert_eq!(dead, [0, 2]);
     }
 
     #[test]
-    fn goldstein_no_neighbors_tied_candidates_both_survive() {
+    fn goldstein_preserves_tied_lowest() {
         let mut self_e = SelfEnergyTable::new(&[3]);
         self_e.set(0, 0, 3.0);
         self_e.set(0, 1, 3.0);
         self_e.set(0, 2, 5.0);
         let pair_e = PairEnergyTable::new(&[]);
         let graph = ContactGraph::build(1, std::iter::empty::<(u32, u32)>());
-        let fixed = vec![false];
 
-        let dead = goldstein_slot(0, &self_e, &pair_e, &graph, &fixed);
-
+        let dead = run_goldstein(0, &self_e, &pair_e, &graph, &[false]);
         assert_eq!(dead, [2]);
     }
 
     #[test]
-    fn goldstein_equal_self_energy_does_not_eliminate() {
+    fn goldstein_exact_tie_survives() {
         let mut self_e = SelfEnergyTable::new(&[2]);
         self_e.set(0, 0, 3.0);
         self_e.set(0, 1, 3.0);
         let pair_e = PairEnergyTable::new(&[]);
         let graph = ContactGraph::build(1, std::iter::empty::<(u32, u32)>());
-        let fixed = vec![false];
 
-        let dead = goldstein_slot(0, &self_e, &pair_e, &graph, &fixed);
-
+        let dead = run_goldstein(0, &self_e, &pair_e, &graph, &[false]);
         assert!(dead.is_empty());
     }
 
     #[test]
-    fn goldstein_with_neighbor_eliminates_dominated_candidate() {
+    fn goldstein_with_pair_energy() {
         let (mut self_e, pair_e, graph) = two_slot([2, 2], &[1.0, 2.0, 3.0, 4.0]);
         self_e.set(0, 0, 5.0);
         self_e.set(0, 1, 2.0);
-        let fixed = vec![false, false];
 
-        let dead = goldstein_slot(0, &self_e, &pair_e, &graph, &fixed);
-
+        let dead = run_goldstein(0, &self_e, &pair_e, &graph, &[false, false]);
         assert_eq!(dead, [0]);
     }
 
     #[test]
-    fn goldstein_with_neighbor_saved_by_pair_term() {
+    fn goldstein_rescued_by_pair_energy() {
         let (mut self_e, pair_e, graph) = two_slot([2, 2], &[-10.0, -10.0, 0.0, 0.0]);
         self_e.set(0, 0, 5.0);
         self_e.set(0, 1, 2.0);
-        let fixed = vec![false, false];
 
-        let dead = goldstein_slot(0, &self_e, &pair_e, &graph, &fixed);
-
+        let dead = run_goldstein(0, &self_e, &pair_e, &graph, &[false, false]);
         assert!(!dead.contains(&0));
     }
 
     #[test]
-    fn goldstein_fixed_neighbor_is_skipped() {
+    fn goldstein_ignores_fixed_neighbor() {
         let (mut self_e, pair_e, graph) = two_slot([2, 2], &[-5.0, -5.0, 0.0, 0.0]);
         self_e.set(0, 0, 5.0);
         self_e.set(0, 1, 2.0);
 
-        let dead_unfixed = goldstein_slot(0, &self_e, &pair_e, &graph, &[false, false]);
+        let dead_unfixed = run_goldstein(0, &self_e, &pair_e, &graph, &[false, false]);
         assert!(
             !dead_unfixed.contains(&0),
             "pair term should rescue candidate 0 when unfixed"
         );
 
-        let dead_fixed = goldstein_slot(0, &self_e, &pair_e, &graph, &[false, true]);
+        let dead_fixed = run_goldstein(0, &self_e, &pair_e, &graph, &[false, true]);
         assert!(
             dead_fixed.contains(&0),
             "candidate 0 must be eliminated when neighbor is fixed"
@@ -442,7 +484,7 @@ mod tests {
     }
 
     #[test]
-    fn goldstein_skips_already_pruned_candidates() {
+    fn goldstein_skips_pruned() {
         let mut self_e = SelfEnergyTable::new(&[3]);
         self_e.set(0, 0, 1.0);
         self_e.set(0, 1, 5.0);
@@ -450,79 +492,66 @@ mod tests {
         self_e.prune(0, 2);
         let pair_e = PairEnergyTable::new(&[]);
         let graph = ContactGraph::build(1, std::iter::empty::<(u32, u32)>());
-        let fixed = vec![false];
 
-        let dead = goldstein_slot(0, &self_e, &pair_e, &graph, &fixed);
-
+        let dead = run_goldstein(0, &self_e, &pair_e, &graph, &[false]);
         assert!(dead.contains(&1));
         assert!(!dead.contains(&2));
     }
 
     #[test]
-    fn goldstein_eliminates_candidate_from_right_side_of_edge() {
+    fn goldstein_right_side_of_edge() {
         let (self_e, pair_e, graph) = two_slot([2, 2], &[0.0, 2.0, 0.0, 2.0]);
-        let fixed = vec![false, false];
 
-        let dead = goldstein_slot(1, &self_e, &pair_e, &graph, &fixed);
-
+        let dead = run_goldstein(1, &self_e, &pair_e, &graph, &[false, false]);
         assert_eq!(dead, [1]);
     }
 
     #[test]
-    fn split_eliminates_candidate_when_goldstein_cannot() {
+    fn split_succeeds_where_goldstein_fails() {
         let (self_e, pair_e, graph) = two_slot([3, 2], &[10.0, -10.0, 11.0, -15.0, 0.0, 5.0]);
-        let fixed = vec![false, false];
+        let fixed = [false, false];
 
-        let g_dead = goldstein_slot(0, &self_e, &pair_e, &graph, &fixed);
-        assert!(
-            !g_dead.contains(&0),
-            "Goldstein must not eliminate s=0 in this case"
-        );
+        let g_dead = run_goldstein(0, &self_e, &pair_e, &graph, &fixed);
+        assert!(!g_dead.contains(&0), "Goldstein must not eliminate s=0");
 
-        let s_dead = split_slot(0, &self_e, &pair_e, &graph, &fixed);
+        let s_dead = run_split(0, &self_e, &pair_e, &graph, &fixed);
         assert!(s_dead.contains(&0), "Split must eliminate s=0");
     }
 
     #[test]
-    fn split_does_not_fire_when_criterion_fails_for_some_vk() {
+    fn split_blocked_by_surviving_vk() {
         let (self_e, pair_e, graph) = two_slot([2, 2], &[5.0, -100.0, 0.0, 0.0]);
-        let fixed = vec![false, false];
 
-        let dead = split_slot(0, &self_e, &pair_e, &graph, &fixed);
-
+        let dead = run_split(0, &self_e, &pair_e, &graph, &[false, false]);
         assert!(!dead.contains(&0));
     }
 
     #[test]
-    fn split_with_single_candidate_produces_no_dead() {
+    fn split_single_candidate_no_op() {
         let mut self_e = SelfEnergyTable::new(&[2, 2]);
         self_e.set(0, 0, 0.0);
         self_e.prune(0, 1);
         let pair_e = PairEnergyTable::new(&[(2, 2)]);
         let graph = ContactGraph::build(2, [(0u32, 1u32)]);
-        let fixed = vec![false, false];
 
-        let dead = split_slot(0, &self_e, &pair_e, &graph, &fixed);
-
+        let dead = run_split(0, &self_e, &pair_e, &graph, &[false, false]);
         assert!(dead.is_empty());
     }
 
     #[test]
-    fn split_with_no_neighbors_produces_no_dead() {
+    fn split_no_neighbors_no_op() {
         let mut self_e = SelfEnergyTable::new(&[3]);
         self_e.set(0, 0, 1.0);
         self_e.set(0, 1, 5.0);
         let pair_e = PairEnergyTable::new(&[]);
         let graph = ContactGraph::build(1, std::iter::empty::<(u32, u32)>());
-        let fixed = vec![false];
 
-        let dead = split_slot(0, &self_e, &pair_e, &graph, &fixed);
-
+        let dead = run_split(0, &self_e, &pair_e, &graph, &[false]);
         assert!(dead.is_empty());
     }
 
     #[test]
-    fn absorb_folds_pair_energy_into_unfixed_neighbor() {
+    fn absorb_folds_into_neighbor() {
         let (mut self_e, pair_e, graph) = two_slot([1, 2], &[3.0, 7.0]);
         let mut fixed = vec![false, false];
 
@@ -535,7 +564,7 @@ mod tests {
     }
 
     #[test]
-    fn absorb_does_not_touch_multi_candidate_slot() {
+    fn absorb_no_op_multi_candidate() {
         let (mut self_e, pair_e, graph) = two_slot([2, 2], &[1.0, 2.0, 3.0, 4.0]);
         let mut fixed = vec![false, false];
 
@@ -548,7 +577,7 @@ mod tests {
     }
 
     #[test]
-    fn absorb_skips_already_fixed_neighbor() {
+    fn absorb_skips_fixed_neighbor() {
         let (mut self_e, pair_e, graph) = two_slot([1, 1], &[5.0]);
         let mut fixed = vec![false, true];
 
@@ -559,7 +588,7 @@ mod tests {
     }
 
     #[test]
-    fn absorb_no_op_when_all_already_fixed() {
+    fn absorb_no_op_all_fixed() {
         let (mut self_e, pair_e, graph) = two_slot([1, 2], &[3.0, 7.0]);
         let mut fixed = vec![true, false];
 
@@ -570,7 +599,7 @@ mod tests {
     }
 
     #[test]
-    fn absorb_skips_pruned_candidates_at_neighbor() {
+    fn absorb_skips_pruned() {
         let (mut self_e, pair_e, graph) = two_slot([1, 2], &[3.0, 7.0]);
         self_e.prune(1, 1);
         let mut fixed = vec![false, false];
@@ -582,7 +611,7 @@ mod tests {
     }
 
     #[test]
-    fn absorb_right_side_fixed_slot_absorbs_into_neighbor() {
+    fn absorb_right_side_of_edge() {
         let (mut self_e, pair_e, graph) = two_slot([2, 1], &[3.0, 7.0]);
         let mut fixed = vec![false, false];
 
@@ -595,14 +624,13 @@ mod tests {
     }
 
     #[test]
-    fn dee_no_op_on_single_candidate_slots() {
+    fn dee_single_candidates_no_op() {
         let (mut self_e, pair_e, graph) = two_slot([1, 1], &[1.0]);
-        let n = dee(&mut self_e, &pair_e, &graph);
-        assert_eq!(n, 0);
+        assert_eq!(dee(&mut self_e, &pair_e, &graph), 0);
     }
 
     #[test]
-    fn dee_returns_total_eliminated_count() {
+    fn dee_returns_elimination_count() {
         let (mut self_e, pair_e, graph) = two_slot([2, 2], &[0.0; 4]);
         self_e.set(0, 0, 5.0);
         self_e.set(0, 1, 1.0);
@@ -619,7 +647,7 @@ mod tests {
     }
 
     #[test]
-    fn dee_does_not_eliminate_equal_energy_candidates() {
+    fn dee_preserves_tied_candidates() {
         let (mut self_e, pair_e, graph) = two_slot([2, 1], &[0.0, 0.0]);
         self_e.set(0, 0, 4.0);
         self_e.set(0, 1, 4.0);
@@ -631,7 +659,7 @@ mod tests {
     }
 
     #[test]
-    fn dee_converges_to_single_survivor_per_slot() {
+    fn dee_full_convergence() {
         let mut self_e = SelfEnergyTable::new(&[5, 5, 5]);
         for s in 0..3 {
             self_e.set(s, 0, 0.0);
@@ -647,7 +675,7 @@ mod tests {
 
         assert_eq!(n, 12);
         for s in 0..3 {
-            assert_eq!(alive(&self_e, s), [0]);
+            assert_eq!(alive_at(&self_e, s), [0]);
         }
     }
 }

--- a/crates/dreid-pack/src/pack/phase/dee.rs
+++ b/crates/dreid-pack/src/pack/phase/dee.rs
@@ -341,16 +341,10 @@ mod tests {
         pair_data: &[f32],
     ) -> (SelfEnergyTable, PairEnergyTable, ContactGraph) {
         let self_e = SelfEnergyTable::new(&counts);
-        let pair_e = PairEnergyTable::new(&[(counts[0], counts[1])]);
-        let graph = ContactGraph::build(2, [(0u32, 1u32)]);
+        let mut pair_e = PairEnergyTable::new(&[(counts[0], counts[1])]);
         debug_assert_eq!(pair_data.len(), counts[0] as usize * counts[1] as usize);
-        let mut pair_e = pair_e;
-        let (ni, nj) = (counts[0] as usize, counts[1] as usize);
-        for ri in 0..ni {
-            for rj in 0..nj {
-                pair_e.set(0, ri, rj, pair_data[ri * nj + rj]);
-            }
-        }
+        pair_e.matrices_mut()[0].copy_from_slice(pair_data);
+        let graph = ContactGraph::build(2, [(0u32, 1u32)]);
         (self_e, pair_e, graph)
     }
 

--- a/crates/dreid-pack/src/pack/phase/dp.rs
+++ b/crates/dreid-pack/src/pack/phase/dp.rs
@@ -17,7 +17,7 @@ const TREEWIDTH_CUT: usize = 5;
 /// Initial threshold for rank-1 edge decomposition.
 const EDGE_DECOMP_THRESHOLD_INIT: f32 = 0.5;
 
-/// Minimum work before parallelising the inner DP loop.
+/// Minimum work before parallelizing the inner DP loop.
 const PAR_SEP_THRESHOLD: usize = 256;
 
 /// Sentinel value mapping a child separator slot to its parent's eliminated vertex.
@@ -31,7 +31,7 @@ struct BitMatrix {
 }
 
 impl BitMatrix {
-    /// Creates a zero-initialised matrix for `n` vertices.
+    /// Creates a zero-initialized matrix for `n` vertices.
     fn new(n: usize) -> Self {
         let stride = n.div_ceil(64);
         Self {

--- a/crates/dreid-pack/src/pack/phase/dp.rs
+++ b/crates/dreid-pack/src/pack/phase/dp.rs
@@ -972,7 +972,6 @@ fn level_order(tree: &[TreeNode]) -> Vec<Vec<usize>> {
 fn dp_node(ni: usize, ctx: &DpContext, messages: &[Vec<f32>]) -> (Vec<f32>, Vec<usize>) {
     let nd = &ctx.nodes[ni];
     let elim_alive = &ctx.alive_data[ctx.alive_off[nd.elim_ci]..ctx.alive_off[nd.elim_ci + 1]];
-    let work = nd.sep_total * elim_alive.len();
 
     let process_sep = |sep_flat: usize| -> (f32, usize) {
         let mut sep_rots = [0usize; TREEWIDTH_CUT + 1];
@@ -1020,11 +1019,11 @@ fn dp_node(ni: usize, ctx: &DpContext, messages: &[Vec<f32>]) -> (Vec<f32>, Vec<
         (best_e, best_r)
     };
 
-    if work >= PAR_SEP_THRESHOLD {
-        (0..nd.sep_total).into_par_iter().map(process_sep).unzip()
-    } else {
-        (0..nd.sep_total).map(process_sep).unzip()
-    }
+    (0..nd.sep_total)
+        .into_par_iter()
+        .with_min_len(PAR_SEP_THRESHOLD)
+        .map(process_sep)
+        .unzip()
 }
 
 /// Top-down backtracking: assigns rotamers from root to leaves.

--- a/crates/dreid-pack/src/pack/phase/dp.rs
+++ b/crates/dreid-pack/src/pack/phase/dp.rs
@@ -17,6 +17,73 @@ const TREEWIDTH_CUT: usize = 5;
 /// Initial threshold for rank-1 edge decomposition.
 const EDGE_DECOMP_THRESHOLD_INIT: f32 = 0.5;
 
+/// Minimum work before parallelising the inner DP loop.
+const PAR_SEP_THRESHOLD: usize = 256;
+
+/// Sentinel value mapping a child separator slot to its parent's eliminated vertex.
+const ELIM_MARKER: u32 = u32::MAX;
+
+/// Compact symmetric adjacency matrix stored as a flat array of `u64` words.
+struct BitMatrix {
+    data: Vec<u64>,
+    stride: usize,
+    n: usize,
+}
+
+impl BitMatrix {
+    /// Creates a zero-initialised matrix for `n` vertices.
+    fn new(n: usize) -> Self {
+        let stride = n.div_ceil(64);
+        Self {
+            data: vec![0u64; n * stride],
+            stride,
+            n,
+        }
+    }
+
+    /// Creates a matrix from an adjacency-list representation.
+    fn from_adj(adj: &[Vec<u32>]) -> Self {
+        let mut m = Self::new(adj.len());
+        for (v, nbrs) in adj.iter().enumerate() {
+            for &u in nbrs {
+                m.set(v, u as usize);
+            }
+        }
+        m
+    }
+
+    /// Marks the edge (v, u) as present.
+    fn set(&mut self, v: usize, u: usize) {
+        self.data[v * self.stride + u / 64] |= 1u64 << (u % 64);
+    }
+
+    /// Returns `true` if the edge (v, u) is present.
+    fn test(&self, v: usize, u: usize) -> bool {
+        self.data[v * self.stride + u / 64] & (1u64 << (u % 64)) != 0
+    }
+
+    /// Returns the raw word slice for row `v`.
+    fn row(&self, v: usize) -> &[u64] {
+        &self.data[v * self.stride..(v + 1) * self.stride]
+    }
+
+    /// Tests bit `u` in a pre-fetched row slice.
+    fn test_in_row(row: &[u64], u: usize) -> bool {
+        row[u / 64] & (1u64 << (u % 64)) != 0
+    }
+
+    /// Makes `sep` vertices pairwise adjacent.
+    fn fill_in(&mut self, sep: &[u32]) {
+        for i in 0..sep.len() {
+            for j in (i + 1)..sep.len() {
+                let (a, b) = (sep[i] as usize, sep[j] as usize);
+                self.set(a, b);
+                self.set(b, a);
+            }
+        }
+    }
+}
+
 /// Finds the Global Minimum Energy Conformation (GMEC) for remaining
 /// multi-candidate slots via tree-decomposition dynamic programming.
 /// Returns one rotamer index per slot.
@@ -119,6 +186,19 @@ fn best_by_self(self_e: &SelfEnergyTable, s: usize) -> usize {
     best_r
 }
 
+/// Returns the index of the rotamer with minimum finite energy.
+fn min_energy_rot(se: &[f32]) -> usize {
+    let mut best_r = 0;
+    let mut best_e = PRUNED;
+    for (r, &e) in se.iter().enumerate() {
+        if e < best_e {
+            best_e = e;
+            best_r = r;
+        }
+    }
+    best_r
+}
+
 /// Returns `true` if any alive pair has `|pair_e| > PAIR_CUT`.
 fn is_significant(
     self_e: &SelfEnergyTable,
@@ -146,7 +226,7 @@ fn is_significant(
     })
 }
 
-/// Pair-energy lookup for `(ci_at_slot_i, cj_at_neighbor)` on `edge`.
+/// Pair-energy lookup respecting the left/right orientation of an edge.
 fn pair_val(mat: &[f32], stride: usize, is_left: bool, ci: usize, cj: usize) -> f32 {
     if is_left {
         mat[ci * stride + cj]
@@ -155,7 +235,8 @@ fn pair_val(mat: &[f32], stride: usize, is_left: bool, ci: usize, cj: usize) -> 
     }
 }
 
-/// Finds connected components in the work graph, returning component-local indices.
+/// Finds connected components among active vertices, returning per-component
+/// vertex lists (in local indices).
 fn find_components(n: usize, adj: &[Vec<u32>], active: &[bool]) -> Vec<Vec<u32>> {
     let mut visited = vec![false; n];
     let mut components = Vec::new();
@@ -266,21 +347,8 @@ fn solve_component(
     (0..cn).map(|ci| (gi(ci), result[ci])).collect()
 }
 
-/// Returns the index of the rotamer with minimum finite energy.
-fn min_energy_rot(se: &[f32]) -> usize {
-    let mut best_r = 0;
-    let mut best_e = PRUNED;
-    for (r, &e) in se.iter().enumerate() {
-        if e < best_e {
-            best_e = e;
-            best_r = r;
-        }
-    }
-    best_r
-}
-
 /// Decomposes edges whose pair energy is well-approximated by a rank-1
-/// factorization `pair(m,n) ≈ a[m] + b[n]`, folding marginals into self-energy.
+/// factorisation `pair(m,n) ≈ a[m] + b[n]`, folding marginals into self-energy.
 fn edge_decompose(
     adj: &mut [Vec<u32>],
     work_edges: &mut Vec<(u32, u32, u32)>,
@@ -377,7 +445,8 @@ fn edge_decompose(
 }
 
 /// Maximum Cardinality Search. Produces a PEO when the graph is chordal.
-fn mcs_order(matrix: &[bool], n: usize) -> Vec<usize> {
+fn mcs_order(matrix: &BitMatrix) -> Vec<usize> {
+    let n: usize = matrix.n;
     let mut numbered = vec![false; n];
     let mut card = vec![0u32; n];
     let mut sigma = vec![0usize; n];
@@ -390,7 +459,7 @@ fn mcs_order(matrix: &[bool], n: usize) -> Vec<usize> {
         sigma[v] = i;
         numbered[v] = true;
         for u in 0..n {
-            if !numbered[u] && matrix[v * n + u] {
+            if !numbered[u] && matrix.test(v, u) {
                 card[u] += 1;
             }
         }
@@ -405,7 +474,8 @@ fn mcs_order(matrix: &[bool], n: usize) -> Vec<usize> {
 
 /// Returns `true` if `order` is a Perfect Elimination Ordering: for each
 /// vertex, its first later neighbor is adjacent to all other later neighbors.
-fn is_peo(matrix: &[bool], n: usize, order: &[usize]) -> bool {
+fn is_peo(matrix: &BitMatrix, order: &[usize]) -> bool {
+    let n = matrix.n;
     let mut pos = vec![0usize; n];
     for (i, &v) in order.iter().enumerate() {
         pos[v] = i;
@@ -414,17 +484,17 @@ fn is_peo(matrix: &[bool], n: usize, order: &[usize]) -> bool {
     for (i, &v) in order.iter().enumerate() {
         let mut f = usize::MAX;
         let mut f_pos = usize::MAX;
-        for u in 0..n {
-            if matrix[v * n + u] && pos[u] > i && pos[u] < f_pos {
-                f_pos = pos[u];
+        for (u, &pu) in pos.iter().enumerate() {
+            if matrix.test(v, u) && pu > i && pu < f_pos {
+                f_pos = pu;
                 f = u;
             }
         }
         if f == usize::MAX {
             continue;
         }
-        for u in 0..n {
-            if u != f && matrix[v * n + u] && pos[u] > i && !matrix[f * n + u] {
+        for (u, &pu) in pos.iter().enumerate() {
+            if u != f && matrix.test(v, u) && pu > i && !matrix.test(f, u) {
                 return false;
             }
         }
@@ -438,45 +508,40 @@ struct Bag {
     sep: Vec<u32>,
 }
 
-/// Builds elimination bags using the best available heuristic (MCS for chordal, min-fill otherwise).
+/// Builds elimination bags using the best heuristic: MCS for chordal graphs,
+/// incremental min-fill otherwise.
 fn eliminate(n: usize, adj: &[Vec<u32>], max_width: usize) -> Option<(Vec<Bag>, usize)> {
     if n == 0 {
         return Some((Vec::new(), 0));
     }
 
-    let mut matrix = vec![false; n * n];
-    for (v, nbrs) in adj.iter().enumerate() {
-        for &u in nbrs {
-            matrix[v * n + u as usize] = true;
-        }
+    let mut matrix = BitMatrix::from_adj(adj);
+
+    let mcs = mcs_order(&matrix);
+    if is_peo(&matrix, &mcs) {
+        return build_bags(&mut matrix, &mcs, max_width);
     }
 
-    let mcs = mcs_order(&matrix, n);
-    if is_peo(&matrix, n, &mcs) {
-        return build_bags(&mut matrix, n, &mcs, max_width);
-    }
-
-    build_bags_min_fill(&mut matrix, n, max_width)
+    build_bags_min_fill(&mut matrix, max_width)
 }
 
 /// Builds bags following a predetermined elimination ordering.
 fn build_bags(
-    matrix: &mut [bool],
-    n: usize,
+    matrix: &mut BitMatrix,
     order: &[usize],
     max_width: usize,
 ) -> Option<(Vec<Bag>, usize)> {
-    let mut eliminated = vec![false; n];
-    let mut bags = Vec::with_capacity(n);
+    let mut eliminated = vec![false; matrix.n];
+    let mut bags = Vec::with_capacity(matrix.n);
     let mut width = 0;
 
     for &v in order {
-        let sep = collect_sep(matrix, n, v, &eliminated);
+        let sep = collect_sep(matrix, v, &eliminated);
         if sep.len() > max_width {
             return None;
         }
         width = width.max(sep.len());
-        apply_fill_in(matrix, n, &sep);
+        matrix.fill_in(&sep);
         eliminated[v] = true;
         bags.push(Bag {
             elim: v as u32,
@@ -488,17 +553,14 @@ fn build_bags(
 }
 
 /// Builds bags with incremental min-fill vertex selection using a priority queue.
-fn build_bags_min_fill(
-    matrix: &mut [bool],
-    n: usize,
-    max_width: usize,
-) -> Option<(Vec<Bag>, usize)> {
+fn build_bags_min_fill(matrix: &mut BitMatrix, max_width: usize) -> Option<(Vec<Bag>, usize)> {
+    let n = matrix.n;
     let mut eliminated = vec![false; n];
     let mut bags = Vec::with_capacity(n);
     let mut width = 0;
 
     let mut fill_cost: Vec<u32> = (0..n)
-        .map(|v| compute_fill(matrix, n, v, &eliminated))
+        .map(|v| compute_fill(matrix, v, &eliminated))
         .collect();
     let mut epoch = vec![0u32; n];
 
@@ -523,7 +585,7 @@ fn build_bags_min_fill(
             break v;
         };
 
-        let sep = collect_sep(matrix, n, v, &eliminated);
+        let sep = collect_sep(matrix, v, &eliminated);
         if sep.len() > max_width {
             return None;
         }
@@ -533,9 +595,9 @@ fn build_bags_min_fill(
         for i in 0..sep.len() {
             for j in (i + 1)..sep.len() {
                 let (a, b) = (sep[i] as usize, sep[j] as usize);
-                if !matrix[a * n + b] {
-                    matrix[a * n + b] = true;
-                    matrix[b * n + a] = true;
+                if !matrix.test(a, b) {
+                    matrix.set(a, b);
+                    matrix.set(b, a);
                     affected.push(a);
                     affected.push(b);
                 }
@@ -549,8 +611,8 @@ fn build_bags_min_fill(
         });
 
         let mut dirty: Vec<usize> = Vec::new();
-        for u in 0..n {
-            if !eliminated[u] && matrix[v * n + u] {
+        for (u, &elim) in eliminated.iter().enumerate() {
+            if !elim && matrix.test(v, u) {
                 dirty.push(u);
             }
         }
@@ -562,7 +624,7 @@ fn build_bags_min_fill(
             if eliminated[u] {
                 continue;
             }
-            let new_cost = compute_fill(matrix, n, u, &eliminated);
+            let new_cost = compute_fill(matrix, u, &eliminated);
             if new_cost != fill_cost[u] {
                 fill_cost[u] = new_cost;
                 epoch[u] = epoch[u].wrapping_add(1);
@@ -575,18 +637,18 @@ fn build_bags_min_fill(
 }
 
 /// Counts the number of missing edges among alive neighbors of `v`.
-fn compute_fill(matrix: &[bool], n: usize, v: usize, eliminated: &[bool]) -> u32 {
-    let row = &matrix[v * n..(v + 1) * n];
-    let mut fill = 0u32;
-    for a in 0..n {
-        if a == v || eliminated[a] || !row[a] {
-            continue;
+fn compute_fill(matrix: &BitMatrix, v: usize, eliminated: &[bool]) -> u32 {
+    let mut nbrs: Vec<usize> = Vec::new();
+    for (u, &elim) in eliminated.iter().enumerate() {
+        if u != v && !elim && matrix.test(v, u) {
+            nbrs.push(u);
         }
-        for b in (a + 1)..n {
-            if b == v || eliminated[b] || !row[b] {
-                continue;
-            }
-            if !matrix[a * n + b] {
+    }
+    let mut fill = 0u32;
+    for i in 0..nbrs.len() {
+        let row_a = matrix.row(nbrs[i]);
+        for &b in &nbrs[i + 1..] {
+            if !BitMatrix::test_in_row(row_a, b) {
                 fill += 1;
             }
         }
@@ -594,23 +656,12 @@ fn compute_fill(matrix: &[bool], n: usize, v: usize, eliminated: &[bool]) -> u32
     fill
 }
 
-/// Ascending alive neighbours of `v` (separator at elimination time).
-fn collect_sep(matrix: &[bool], n: usize, v: usize, eliminated: &[bool]) -> Vec<u32> {
-    (0..n)
-        .filter(|&u| u != v && !eliminated[u] && matrix[v * n + u])
+/// Collects alive (non-eliminated) neighbors of `v` as the separator.
+fn collect_sep(matrix: &BitMatrix, v: usize, eliminated: &[bool]) -> Vec<u32> {
+    (0..matrix.n)
+        .filter(|&u| u != v && !eliminated[u] && matrix.test(v, u))
         .map(|u| u as u32)
         .collect()
-}
-
-/// Makes `sep` vertices pairwise adjacent (clique fill-in).
-fn apply_fill_in(matrix: &mut [bool], n: usize, sep: &[u32]) {
-    for i in 0..sep.len() {
-        for j in (i + 1)..sep.len() {
-            let (a, b) = (sep[i] as usize, sep[j] as usize);
-            matrix[a * n + b] = true;
-            matrix[b * n + a] = true;
-        }
-    }
 }
 
 /// A node in the rooted elimination tree.
@@ -659,219 +710,6 @@ fn root_tree(bags: &[Bag]) -> Vec<TreeNode> {
     nodes
 }
 
-/// Runs the full tree-decomposition DP and writes the GMEC into `result`.
-fn tree_dp(
-    tree: &[TreeNode],
-    local_self: &[Vec<f32>],
-    pair_e: &PairEnergyTable,
-    graph: &ContactGraph,
-    gi: impl Fn(usize) -> usize,
-    work_edges: &[(u32, u32, u32)],
-    result: &mut [usize],
-) {
-    let n_nodes = tree.len();
-    if n_nodes == 0 {
-        return;
-    }
-
-    let cn = local_self.len();
-    let edge_map = build_edge_map(work_edges, &gi, graph);
-
-    let (alive_data, alive_off) = build_alive_table(local_self);
-
-    let max_cands = local_self.iter().map(|se| se.len()).max().unwrap_or(0);
-    let mut rot_to_idx = vec![u32::MAX; cn * max_cands];
-    for ci in 0..cn {
-        let alive = &alive_data[alive_off[ci]..alive_off[ci + 1]];
-        for (idx, &r) in alive.iter().enumerate() {
-            rot_to_idx[ci * max_cands + r] = idx as u32;
-        }
-    }
-
-    let nodes: Vec<NodeInfo> = tree
-        .iter()
-        .map(|tn| NodeInfo::new(tn, &alive_off))
-        .collect();
-
-    let node_edges: Vec<Vec<EdgeInfo>> = nodes
-        .iter()
-        .map(|nd| {
-            nd.sep_cis
-                .iter()
-                .enumerate()
-                .filter_map(|(d, &sci)| {
-                    let elim_is_lo = nd.elim_ci < sci;
-                    let key = if elim_is_lo {
-                        (nd.elim_ci as u32, sci as u32)
-                    } else {
-                        (sci as u32, nd.elim_ci as u32)
-                    };
-                    let &(edge_idx, lo_is_left) = edge_map.get(&key)?;
-                    let is_left = if elim_is_lo { lo_is_left } else { !lo_is_left };
-                    let mat = pair_e.matrix(edge_idx);
-                    let stride = pair_e.dims(edge_idx).1;
-                    Some(EdgeInfo {
-                        sep_dim: d,
-                        mat,
-                        stride,
-                        is_left,
-                    })
-                })
-                .collect()
-        })
-        .collect();
-
-    const ELIM_MARKER: u32 = u32::MAX;
-    let child_maps: Vec<Vec<Vec<u32>>> = (0..n_nodes)
-        .map(|ni| {
-            tree[ni]
-                .children
-                .iter()
-                .map(|&cni| {
-                    let child_node = &nodes[cni as usize];
-                    child_node
-                        .sep_cis
-                        .iter()
-                        .map(|&c_sci| {
-                            if c_sci == nodes[ni].elim_ci {
-                                ELIM_MARKER
-                            } else {
-                                nodes[ni].sep_cis.iter().position(|&x| x == c_sci).unwrap() as u32
-                            }
-                        })
-                        .collect()
-                })
-                .collect()
-        })
-        .collect();
-
-    let mut messages: Vec<Vec<f32>> = (0..n_nodes).map(|_| Vec::new()).collect();
-    let mut tracebacks: Vec<Vec<usize>> = (0..n_nodes).map(|_| Vec::new()).collect();
-
-    let topo = topo_order(tree);
-
-    let max_sep = nodes.iter().map(|nd| nd.sep_cis.len()).max().unwrap_or(0);
-    let mut sep_rots_buf = vec![0usize; max_sep];
-
-    for &ni in &topo {
-        let nd = &nodes[ni];
-        let elim_alive = &alive_data[alive_off[nd.elim_ci]..alive_off[nd.elim_ci + 1]];
-
-        let mut msg = vec![PRUNED; nd.sep_total];
-        let mut tb = vec![0usize; nd.sep_total];
-
-        let sep_rots = &mut sep_rots_buf[..nd.sep_cis.len()];
-
-        for sep_flat in 0..nd.sep_total {
-            for (d, &ci) in nd.sep_cis.iter().enumerate() {
-                let alive = &alive_data[alive_off[ci]..alive_off[ci + 1]];
-                sep_rots[d] = alive[(sep_flat / nd.sep_strides[d]) % nd.sep_dims[d]];
-            }
-
-            let mut best_e = PRUNED;
-            let mut best_r = 0usize;
-
-            for &er in elim_alive {
-                let mut e = local_self[nd.elim_ci][er];
-
-                for ei in &node_edges[ni] {
-                    e += pair_val(ei.mat, ei.stride, ei.is_left, er, sep_rots[ei.sep_dim]);
-                }
-
-                for (ci_idx, &child_ni) in tree[ni].children.iter().enumerate() {
-                    let child_nd = &nodes[child_ni as usize];
-                    let mapping = &child_maps[ni][ci_idx];
-
-                    let mut child_flat = 0usize;
-                    for (d, &src) in mapping.iter().enumerate() {
-                        let rot = if src == ELIM_MARKER {
-                            er
-                        } else {
-                            sep_rots[src as usize]
-                        };
-                        let alive_idx = rot_to_idx[child_nd.sep_cis[d] * max_cands + rot] as usize;
-                        child_flat += alive_idx * child_nd.sep_strides[d];
-                    }
-
-                    e += messages[child_ni as usize][child_flat];
-                }
-
-                if e < best_e {
-                    best_e = e;
-                    best_r = er;
-                }
-            }
-
-            msg[sep_flat] = best_e;
-            tb[sep_flat] = best_r;
-        }
-
-        messages[ni] = msg;
-        tracebacks[ni] = tb;
-    }
-
-    debug_assert!(
-        nodes[0].sep_cis.is_empty(),
-        "root separator must be empty in a valid elimination tree"
-    );
-
-    result[nodes[0].elim_ci] = tracebacks[0][0];
-
-    backtrack(
-        tree,
-        &nodes,
-        &child_maps,
-        &rot_to_idx,
-        max_cands,
-        &tracebacks,
-        result,
-    );
-}
-
-/// Top-down backtracking: assigns rotamers from root to leaves.
-fn backtrack(
-    tree: &[TreeNode],
-    nodes: &[NodeInfo],
-    child_maps: &[Vec<Vec<u32>>],
-    rot_to_idx: &[u32],
-    max_cands: usize,
-    tracebacks: &[Vec<usize>],
-    result: &mut [usize],
-) {
-    const ELIM_MARKER: u32 = u32::MAX;
-
-    let mut stack: Vec<(usize, usize)> = Vec::new();
-
-    for (ci_idx, &child_ni) in tree[0].children.iter().enumerate() {
-        stack.push((0, ci_idx));
-        let _ = child_ni;
-    }
-
-    while let Some((parent_ni, ci_idx)) = stack.pop() {
-        let child_ni = tree[parent_ni].children[ci_idx] as usize;
-        let child_nd = &nodes[child_ni];
-        let mapping = &child_maps[parent_ni][ci_idx];
-
-        let parent_elim_ci = nodes[parent_ni].elim_ci;
-        let mut child_flat = 0usize;
-        for (d, &src) in mapping.iter().enumerate() {
-            let rot = if src == ELIM_MARKER {
-                result[parent_elim_ci]
-            } else {
-                result[nodes[parent_ni].sep_cis[src as usize]]
-            };
-            let alive_idx = rot_to_idx[child_nd.sep_cis[d] * max_cands + rot] as usize;
-            child_flat += alive_idx * child_nd.sep_strides[d];
-        }
-
-        result[child_nd.elim_ci] = tracebacks[child_ni][child_flat];
-
-        for (grandchild_idx, _) in tree[child_ni].children.iter().enumerate() {
-            stack.push((child_ni, grandchild_idx));
-        }
-    }
-}
-
 /// Pre-computed per-node info for the DP inner loop.
 struct NodeInfo {
     elim_ci: usize,
@@ -913,25 +751,21 @@ struct EdgeInfo<'a> {
     is_left: bool,
 }
 
-/// Builds a HashMap for O(1) edge lookup between component-local slot pairs.
-fn build_edge_map(
-    work_edges: &[(u32, u32, u32)],
-    gi: impl Fn(usize) -> usize,
-    graph: &ContactGraph,
-) -> HashMap<(u32, u32), (usize, bool)> {
-    let mut map = HashMap::with_capacity(work_edges.len());
-    for &(ca, cb, eidx) in work_edges {
-        let eidx = eidx as usize;
-        let (ga, _) = graph.edges()[eidx];
-        let ca_is_left = gi(ca as usize) == ga as usize;
-        let key = (ca.min(cb), ca.max(cb));
-        map.insert(key, (eidx, ca_is_left));
-    }
-    map
+/// Read-only context shared across all DP node evaluations.
+struct DpContext<'a> {
+    tree: &'a [TreeNode],
+    nodes: &'a [NodeInfo],
+    node_edges: &'a [Vec<EdgeInfo<'a>>],
+    child_maps: &'a [Vec<Vec<u32>>],
+    local_self: &'a [Vec<f32>],
+    alive_data: &'a [usize],
+    alive_off: &'a [usize],
+    rot_to_idx: &'a [u32],
+    max_cands: usize,
 }
 
-/// Builds a flat alive-rotamer table: `alive_data[off[ci]..off[ci+1]]` holds
-/// the alive rotamer indices for component-local slot `ci`.
+/// Builds a flat alive-rotamer table: `data[off[ci]..off[ci+1]]` holds the
+/// alive rotamer indices for component-local slot `ci`.
 fn build_alive_table(local_self: &[Vec<f32>]) -> (Vec<usize>, Vec<usize>) {
     let cn = local_self.len();
     let mut offsets = vec![0usize; cn + 1];
@@ -951,24 +785,279 @@ fn build_alive_table(local_self: &[Vec<f32>]) -> (Vec<usize>, Vec<usize>) {
     (data, offsets)
 }
 
-/// Returns a bottom-up topological order of the elimination tree nodes.
-fn topo_order(tree: &[TreeNode]) -> Vec<usize> {
+/// Builds a HashMap for O(1) edge lookup between component-local slot pairs.
+fn build_edge_map(
+    work_edges: &[(u32, u32, u32)],
+    gi: &impl Fn(usize) -> usize,
+    graph: &ContactGraph,
+) -> HashMap<(u32, u32), (usize, bool)> {
+    let mut map = HashMap::with_capacity(work_edges.len());
+    for &(ca, cb, eidx) in work_edges {
+        let eidx = eidx as usize;
+        let (ga, _) = graph.edges()[eidx];
+        let ca_is_left = gi(ca as usize) == ga as usize;
+        let key = (ca.min(cb), ca.max(cb));
+        map.insert(key, (eidx, ca_is_left));
+    }
+    map
+}
+
+/// Builds per-node edge info for elim<->sep pair lookups.
+fn build_node_edges<'a>(
+    nodes: &[NodeInfo],
+    edge_map: &HashMap<(u32, u32), (usize, bool)>,
+    pair_e: &'a PairEnergyTable,
+) -> Vec<Vec<EdgeInfo<'a>>> {
+    nodes
+        .iter()
+        .map(|nd| {
+            nd.sep_cis
+                .iter()
+                .enumerate()
+                .filter_map(|(d, &sci)| {
+                    let (lo, hi) = if nd.elim_ci < sci {
+                        (nd.elim_ci as u32, sci as u32)
+                    } else {
+                        (sci as u32, nd.elim_ci as u32)
+                    };
+                    let &(edge_idx, lo_is_left) = edge_map.get(&(lo, hi))?;
+                    let is_left = if nd.elim_ci < sci {
+                        lo_is_left
+                    } else {
+                        !lo_is_left
+                    };
+                    Some(EdgeInfo {
+                        sep_dim: d,
+                        mat: pair_e.matrix(edge_idx),
+                        stride: pair_e.dims(edge_idx).1,
+                        is_left,
+                    })
+                })
+                .collect()
+        })
+        .collect()
+}
+
+/// Builds the mapping from each child's separator to its parent's namespace.
+fn build_child_maps(tree: &[TreeNode], nodes: &[NodeInfo]) -> Vec<Vec<Vec<u32>>> {
+    (0..tree.len())
+        .map(|ni| {
+            tree[ni]
+                .children
+                .iter()
+                .map(|&cni| {
+                    nodes[cni as usize]
+                        .sep_cis
+                        .iter()
+                        .map(|&c_sci| {
+                            if c_sci == nodes[ni].elim_ci {
+                                ELIM_MARKER
+                            } else {
+                                nodes[ni].sep_cis.iter().position(|&x| x == c_sci).unwrap() as u32
+                            }
+                        })
+                        .collect()
+                })
+                .collect()
+        })
+        .collect()
+}
+
+/// Runs the full tree-decomposition DP and writes the GMEC into `result`.
+fn tree_dp(
+    tree: &[TreeNode],
+    local_self: &[Vec<f32>],
+    pair_e: &PairEnergyTable,
+    graph: &ContactGraph,
+    gi: impl Fn(usize) -> usize + Sync,
+    work_edges: &[(u32, u32, u32)],
+    result: &mut [usize],
+) {
+    let n_nodes = tree.len();
+    if n_nodes == 0 {
+        return;
+    }
+
+    let cn = local_self.len();
+    let edge_map = build_edge_map(work_edges, &gi, graph);
+    let (alive_data, alive_off) = build_alive_table(local_self);
+
+    let max_cands = local_self.iter().map(|se| se.len()).max().unwrap_or(0);
+    let mut rot_to_idx = vec![u32::MAX; cn * max_cands];
+    for ci in 0..cn {
+        let alive = &alive_data[alive_off[ci]..alive_off[ci + 1]];
+        for (idx, &r) in alive.iter().enumerate() {
+            rot_to_idx[ci * max_cands + r] = idx as u32;
+        }
+    }
+
+    let nodes: Vec<NodeInfo> = tree
+        .iter()
+        .map(|tn| NodeInfo::new(tn, &alive_off))
+        .collect();
+    let node_edges = build_node_edges(&nodes, &edge_map, pair_e);
+    let child_maps = build_child_maps(tree, &nodes);
+
+    let ctx = DpContext {
+        tree,
+        nodes: &nodes,
+        node_edges: &node_edges,
+        child_maps: &child_maps,
+        local_self,
+        alive_data: &alive_data,
+        alive_off: &alive_off,
+        rot_to_idx: &rot_to_idx,
+        max_cands,
+    };
+
+    let mut messages: Vec<Vec<f32>> = (0..n_nodes).map(|_| Vec::new()).collect();
+    let mut tracebacks: Vec<Vec<usize>> = (0..n_nodes).map(|_| Vec::new()).collect();
+
+    let levels = level_order(tree);
+
+    for level in levels.iter().rev() {
+        if level.len() == 1 {
+            let ni = level[0];
+            let (msg, tb) = dp_node(ni, &ctx, &messages);
+            messages[ni] = msg;
+            tracebacks[ni] = tb;
+        } else {
+            let results: Vec<(usize, Vec<f32>, Vec<usize>)> = level
+                .par_iter()
+                .map(|&ni| {
+                    let (msg, tb) = dp_node(ni, &ctx, &messages);
+                    (ni, msg, tb)
+                })
+                .collect();
+            for (ni, msg, tb) in results {
+                messages[ni] = msg;
+                tracebacks[ni] = tb;
+            }
+        }
+    }
+
+    debug_assert!(
+        nodes[0].sep_cis.is_empty(),
+        "root separator must be empty in a valid elimination tree"
+    );
+
+    result[nodes[0].elim_ci] = tracebacks[0][0];
+
+    backtrack(&ctx, &tracebacks, result);
+}
+
+/// Groups tree nodes into BFS levels from the root.
+fn level_order(tree: &[TreeNode]) -> Vec<Vec<usize>> {
     let n = tree.len();
     if n == 0 {
         return Vec::new();
     }
 
-    let mut order = Vec::with_capacity(n);
-    let mut queue = std::collections::VecDeque::with_capacity(n);
-    queue.push_back(0usize);
-    while let Some(ni) = queue.pop_front() {
-        order.push(ni);
-        for &child in &tree[ni].children {
-            queue.push_back(child as usize);
+    let mut levels: Vec<Vec<usize>> = Vec::new();
+    let mut current = vec![0usize];
+    while !current.is_empty() {
+        let mut next = Vec::new();
+        for &ni in &current {
+            for &child in &tree[ni].children {
+                next.push(child as usize);
+            }
+        }
+        levels.push(current);
+        current = next;
+    }
+    levels
+}
+
+/// Computes the DP message and traceback for a single tree node.
+fn dp_node(ni: usize, ctx: &DpContext, messages: &[Vec<f32>]) -> (Vec<f32>, Vec<usize>) {
+    let nd = &ctx.nodes[ni];
+    let elim_alive = &ctx.alive_data[ctx.alive_off[nd.elim_ci]..ctx.alive_off[nd.elim_ci + 1]];
+    let work = nd.sep_total * elim_alive.len();
+
+    let process_sep = |sep_flat: usize| -> (f32, usize) {
+        let mut sep_rots = [0usize; TREEWIDTH_CUT + 1];
+        let sep_rots = &mut sep_rots[..nd.sep_cis.len()];
+        for (d, &ci) in nd.sep_cis.iter().enumerate() {
+            let alive = &ctx.alive_data[ctx.alive_off[ci]..ctx.alive_off[ci + 1]];
+            sep_rots[d] = alive[(sep_flat / nd.sep_strides[d]) % nd.sep_dims[d]];
+        }
+
+        let mut best_e = PRUNED;
+        let mut best_r = 0usize;
+
+        for &er in elim_alive {
+            let mut e = ctx.local_self[nd.elim_ci][er];
+
+            for ei in &ctx.node_edges[ni] {
+                e += pair_val(ei.mat, ei.stride, ei.is_left, er, sep_rots[ei.sep_dim]);
+            }
+
+            for (ci_idx, &child_ni) in ctx.tree[ni].children.iter().enumerate() {
+                let child_nd = &ctx.nodes[child_ni as usize];
+                let mapping = &ctx.child_maps[ni][ci_idx];
+
+                let mut child_flat = 0usize;
+                for (d, &src) in mapping.iter().enumerate() {
+                    let rot = if src == ELIM_MARKER {
+                        er
+                    } else {
+                        sep_rots[src as usize]
+                    };
+                    let alive_idx =
+                        ctx.rot_to_idx[child_nd.sep_cis[d] * ctx.max_cands + rot] as usize;
+                    child_flat += alive_idx * child_nd.sep_strides[d];
+                }
+
+                e += messages[child_ni as usize][child_flat];
+            }
+
+            if e < best_e {
+                best_e = e;
+                best_r = er;
+            }
+        }
+
+        (best_e, best_r)
+    };
+
+    if work >= PAR_SEP_THRESHOLD {
+        (0..nd.sep_total).into_par_iter().map(process_sep).unzip()
+    } else {
+        (0..nd.sep_total).map(process_sep).unzip()
+    }
+}
+
+/// Top-down backtracking: assigns rotamers from root to leaves.
+fn backtrack(ctx: &DpContext, tracebacks: &[Vec<usize>], result: &mut [usize]) {
+    let mut stack: Vec<(usize, usize)> = Vec::new();
+
+    for (ci_idx, _) in ctx.tree[0].children.iter().enumerate() {
+        stack.push((0, ci_idx));
+    }
+
+    while let Some((parent_ni, ci_idx)) = stack.pop() {
+        let child_ni = ctx.tree[parent_ni].children[ci_idx] as usize;
+        let child_nd = &ctx.nodes[child_ni];
+        let mapping = &ctx.child_maps[parent_ni][ci_idx];
+
+        let parent_elim_ci = ctx.nodes[parent_ni].elim_ci;
+        let mut child_flat = 0usize;
+        for (d, &src) in mapping.iter().enumerate() {
+            let rot = if src == ELIM_MARKER {
+                result[parent_elim_ci]
+            } else {
+                result[ctx.nodes[parent_ni].sep_cis[src as usize]]
+            };
+            let alive_idx = ctx.rot_to_idx[child_nd.sep_cis[d] * ctx.max_cands + rot] as usize;
+            child_flat += alive_idx * child_nd.sep_strides[d];
+        }
+
+        result[child_nd.elim_ci] = tracebacks[child_ni][child_flat];
+
+        for (grandchild_idx, _) in ctx.tree[child_ni].children.iter().enumerate() {
+            stack.push((child_ni, grandchild_idx));
         }
     }
-    order.reverse();
-    order
 }
 
 #[cfg(test)]
@@ -976,11 +1065,11 @@ mod tests {
     use super::*;
     use approx::assert_abs_diff_eq;
 
-    fn make_matrix(n: usize, edges: &[(usize, usize)]) -> Vec<bool> {
-        let mut m = vec![false; n * n];
+    fn make_matrix(n: usize, edges: &[(usize, usize)]) -> BitMatrix {
+        let mut m = BitMatrix::new(n);
         for &(a, b) in edges {
-            m[a * n + b] = true;
-            m[b * n + a] = true;
+            m.set(a, b);
+            m.set(b, a);
         }
         m
     }
@@ -1013,29 +1102,29 @@ mod tests {
     #[test]
     fn mcs_on_path_produces_peo() {
         let m = make_matrix(3, &[(0, 1), (1, 2)]);
-        let order = mcs_order(&m, 3);
-        assert!(is_peo(&m, 3, &order));
+        let order = mcs_order(&m);
+        assert!(is_peo(&m, &order));
     }
 
     #[test]
     fn mcs_on_triangle_produces_peo() {
         let m = make_matrix(3, &[(0, 1), (0, 2), (1, 2)]);
-        let order = mcs_order(&m, 3);
-        assert!(is_peo(&m, 3, &order));
+        let order = mcs_order(&m);
+        assert!(is_peo(&m, &order));
     }
 
     #[test]
     fn mcs_on_four_cycle_fails_peo() {
         let m = make_matrix(4, &[(0, 1), (1, 2), (2, 3), (3, 0)]);
-        let order = mcs_order(&m, 4);
-        assert!(!is_peo(&m, 4, &order));
+        let order = mcs_order(&m);
+        assert!(!is_peo(&m, &order));
     }
 
     #[test]
     fn is_peo_rejects_non_peo_order_on_chordal_graph() {
         let m = make_matrix(3, &[(0, 1), (1, 2)]);
-        assert!(is_peo(&m, 3, &[0, 1, 2]));
-        assert!(!is_peo(&m, 3, &[1, 0, 2]));
+        assert!(is_peo(&m, &[0, 1, 2]));
+        assert!(!is_peo(&m, &[1, 0, 2]));
     }
 
     #[test]

--- a/crates/dreid-pack/src/pack/phase/dp.rs
+++ b/crates/dreid-pack/src/pack/phase/dp.rs
@@ -497,17 +497,16 @@ fn build_bags_min_fill(
     let mut bags = Vec::with_capacity(n);
     let mut width = 0;
 
-    let mut fill_cost = vec![0u32; n];
+    let mut fill_cost: Vec<u32> = (0..n)
+        .map(|v| compute_fill(matrix, n, v, &eliminated))
+        .collect();
     let mut epoch = vec![0u32; n];
 
-    for v in 0..n {
-        fill_cost[v] = compute_fill(matrix, n, v, &eliminated);
-    }
-
-    let mut heap = BinaryHeap::with_capacity(n);
-    for v in 0..n {
-        heap.push(Reverse((fill_cost[v], v as u32, epoch[v])));
-    }
+    let mut heap: BinaryHeap<_> = fill_cost
+        .iter()
+        .enumerate()
+        .map(|(v, &cost)| Reverse((cost, v as u32, 0u32)))
+        .collect();
 
     for _ in 0..n {
         let v = loop {

--- a/crates/dreid-pack/src/pack/phase/dp.rs
+++ b/crates/dreid-pack/src/pack/phase/dp.rs
@@ -4,6 +4,7 @@ use crate::pack::model::{
 };
 use rayon::prelude::*;
 use std::cmp::Reverse;
+use std::collections::{BinaryHeap, HashMap};
 
 /// Pair-energy significance threshold (kcal/mol). Edges where every surviving
 /// candidate pair has `|pair_e| ≤ PAIR_CUT` are dropped from the work graph.
@@ -384,7 +385,7 @@ fn mcs_order(matrix: &[bool], n: usize) -> Vec<usize> {
     for i in (1..=n).rev() {
         let v = (0..n)
             .filter(|&v| !numbered[v])
-            .min_by_key(|&v| (Reverse(card[v]), v))
+            .max_by_key(|&v| (card[v], Reverse(v)))
             .unwrap();
         sigma[v] = i;
         numbered[v] = true;
@@ -486,7 +487,7 @@ fn build_bags(
     Some((bags, width))
 }
 
-/// Builds bags with dynamic min-fill vertex selection (single pass).
+/// Builds bags with incremental min-fill vertex selection using a priority queue.
 fn build_bags_min_fill(
     matrix: &mut [bool],
     n: usize,
@@ -496,42 +497,102 @@ fn build_bags_min_fill(
     let mut bags = Vec::with_capacity(n);
     let mut width = 0;
 
+    let mut fill_cost = vec![0u32; n];
+    let mut epoch = vec![0u32; n];
+
+    for v in 0..n {
+        fill_cost[v] = compute_fill(matrix, n, v, &eliminated);
+    }
+
+    let mut heap = BinaryHeap::with_capacity(n);
+    for v in 0..n {
+        heap.push(Reverse((fill_cost[v], v as u32, epoch[v])));
+    }
+
     for _ in 0..n {
-        let v = (0..n)
-            .filter(|&v| !eliminated[v])
-            .min_by_key(|&v| {
-                let mut fill = 0u32;
-                for a in 0..n {
-                    if a == v || eliminated[a] || !matrix[v * n + a] {
-                        continue;
-                    }
-                    for b in (a + 1)..n {
-                        if b == v || eliminated[b] || !matrix[v * n + b] {
-                            continue;
-                        }
-                        if !matrix[a * n + b] {
-                            fill += 1;
-                        }
-                    }
-                }
-                (fill, v)
-            })
-            .unwrap();
+        let v = loop {
+            let Reverse((cost, v, g)) = heap.pop().unwrap();
+            let v = v as usize;
+            if eliminated[v] || g != epoch[v] {
+                continue;
+            }
+            if cost != fill_cost[v] {
+                epoch[v] = epoch[v].wrapping_add(1);
+                heap.push(Reverse((fill_cost[v], v as u32, epoch[v])));
+                continue;
+            }
+            break v;
+        };
 
         let sep = collect_sep(matrix, n, v, &eliminated);
         if sep.len() > max_width {
             return None;
         }
         width = width.max(sep.len());
-        apply_fill_in(matrix, n, &sep);
+
+        let mut affected = Vec::new();
+        for i in 0..sep.len() {
+            for j in (i + 1)..sep.len() {
+                let (a, b) = (sep[i] as usize, sep[j] as usize);
+                if !matrix[a * n + b] {
+                    matrix[a * n + b] = true;
+                    matrix[b * n + a] = true;
+                    affected.push(a);
+                    affected.push(b);
+                }
+            }
+        }
+
         eliminated[v] = true;
         bags.push(Bag {
             elim: v as u32,
             sep,
         });
+
+        let mut dirty: Vec<usize> = Vec::new();
+        for u in 0..n {
+            if !eliminated[u] && matrix[v * n + u] {
+                dirty.push(u);
+            }
+        }
+        dirty.extend_from_slice(&affected);
+        dirty.sort_unstable();
+        dirty.dedup();
+
+        for &u in &dirty {
+            if eliminated[u] {
+                continue;
+            }
+            let new_cost = compute_fill(matrix, n, u, &eliminated);
+            if new_cost != fill_cost[u] {
+                fill_cost[u] = new_cost;
+                epoch[u] = epoch[u].wrapping_add(1);
+                heap.push(Reverse((new_cost, u as u32, epoch[u])));
+            }
+        }
     }
 
     Some((bags, width))
+}
+
+/// Counts the number of missing edges among alive neighbors of `v`.
+fn compute_fill(matrix: &[bool], n: usize, v: usize, eliminated: &[bool]) -> u32 {
+    let row = &matrix[v * n..(v + 1) * n];
+    let mut fill = 0u32;
+    for a in 0..n {
+        if a == v || eliminated[a] || !row[a] {
+            continue;
+        }
+        for b in (a + 1)..n {
+            if b == v || eliminated[b] || !row[b] {
+                continue;
+            }
+            if !matrix[a * n + b] {
+                fill += 1;
+            }
+        }
+    }
+    fill
 }
 
 /// Ascending alive neighbours of `v` (separator at elimination time).
@@ -615,7 +676,7 @@ fn tree_dp(
     }
 
     let cn = local_self.len();
-    let edge_tbl = build_edge_table(cn, work_edges, gi, graph);
+    let edge_map = build_edge_map(work_edges, &gi, graph);
 
     let (alive_data, alive_off) = build_alive_table(local_self);
 
@@ -640,12 +701,14 @@ fn tree_dp(
                 .iter()
                 .enumerate()
                 .filter_map(|(d, &sci)| {
-                    let packed = edge_tbl[nd.elim_ci * cn + sci];
-                    if packed == u32::MAX {
-                        return None;
-                    }
-                    let edge_idx = (packed >> 1) as usize;
-                    let is_left = (packed & 1) != 0;
+                    let elim_is_lo = nd.elim_ci < sci;
+                    let key = if elim_is_lo {
+                        (nd.elim_ci as u32, sci as u32)
+                    } else {
+                        (sci as u32, nd.elim_ci as u32)
+                    };
+                    let &(edge_idx, lo_is_left) = edge_map.get(&key)?;
+                    let is_left = if elim_is_lo { lo_is_left } else { !lo_is_left };
                     let mat = pair_e.matrix(edge_idx);
                     let stride = pair_e.dims(edge_idx).1;
                     Some(EdgeInfo {
@@ -851,24 +914,21 @@ struct EdgeInfo<'a> {
     is_left: bool,
 }
 
-/// Builds a flat cn×cn table for O(1) edge lookup between component-local slots.
-/// Returns `u32::MAX` for no-edge, otherwise `(edge_idx << 1) | is_left_bit`.
-fn build_edge_table(
-    cn: usize,
+/// Builds a HashMap for O(1) edge lookup between component-local slot pairs.
+fn build_edge_map(
     work_edges: &[(u32, u32, u32)],
     gi: impl Fn(usize) -> usize,
     graph: &ContactGraph,
-) -> Vec<u32> {
-    let mut tbl = vec![u32::MAX; cn * cn];
+) -> HashMap<(u32, u32), (usize, bool)> {
+    let mut map = HashMap::with_capacity(work_edges.len());
     for &(ca, cb, eidx) in work_edges {
         let eidx = eidx as usize;
         let (ga, _) = graph.edges()[eidx];
         let ca_is_left = gi(ca as usize) == ga as usize;
-
-        tbl[ca as usize * cn + cb as usize] = ((eidx as u32) << 1) | ca_is_left as u32;
-        tbl[cb as usize * cn + ca as usize] = ((eidx as u32) << 1) | (!ca_is_left) as u32;
+        let key = (ca.min(cb), ca.max(cb));
+        map.insert(key, (eidx, ca_is_left));
     }
-    tbl
+    map
 }
 
 /// Builds a flat alive-rotamer table: `alive_data[off[ci]..off[ci+1]]` holds

--- a/crates/dreid-pack/src/pack/phase/dp.rs
+++ b/crates/dreid-pack/src/pack/phase/dp.rs
@@ -1089,13 +1089,8 @@ mod tests {
     ) -> (SelfEnergyTable, PairEnergyTable, ContactGraph) {
         let self_e = SelfEnergyTable::new(&counts);
         let mut pair_e = PairEnergyTable::new(&[(counts[0], counts[1])]);
+        pair_e.matrices_mut()[0].copy_from_slice(pair_data);
         let graph = ContactGraph::build(2, [(0u32, 1u32)]);
-        let (ni, nj) = (counts[0] as usize, counts[1] as usize);
-        for ri in 0..ni {
-            for rj in 0..nj {
-                pair_e.set(0, ri, rj, pair_data[ri * nj + rj]);
-            }
-        }
         (self_e, pair_e, graph)
     }
 
@@ -1315,9 +1310,9 @@ mod tests {
         let mut pair_e = PairEnergyTable::new(&[(2, 2), (2, 2), (2, 2)]);
         let graph = ContactGraph::build(3, [(0u32, 1u32), (0u32, 2u32), (1u32, 2u32)]);
 
-        for edge in 0..3 {
-            pair_e.set(edge, 0, 1, 10.0);
-            pair_e.set(edge, 1, 0, 10.0);
+        for s in pair_e.matrices_mut() {
+            s[0 * 2 + 1] = 10.0;
+            s[1 * 2 + 0] = 10.0;
         }
 
         let result = dp(&mut self_e, &pair_e, &graph);

--- a/crates/dreid-pack/src/pack/phase/pair.rs
+++ b/crates/dreid-pack/src/pack/phase/pair.rs
@@ -36,28 +36,48 @@ pub fn pair(
         })
         .collect();
 
-    let results = match (&ff.vdw, c_d) {
-        (VdwMatrix::LennardJones(m), None) => {
-            compute::<_, false>(&LjKernel(m), slots, conformations, graph, &ff.hbond, 0.0)
-        }
-        (VdwMatrix::LennardJones(m), Some(c)) => {
-            compute::<_, true>(&LjKernel(m), slots, conformations, graph, &ff.hbond, c)
-        }
-        (VdwMatrix::Buckingham(m), None) => {
-            compute::<_, false>(&BuckKernel(m), slots, conformations, graph, &ff.hbond, 0.0)
-        }
-        (VdwMatrix::Buckingham(m), Some(c)) => {
-            compute::<_, true>(&BuckKernel(m), slots, conformations, graph, &ff.hbond, c)
-        }
-    };
-
     let mut table = PairEnergyTable::new(&dims);
-    for (e, energies) in results.into_iter().enumerate() {
-        let nj = dims[e].1 as usize;
-        for (idx, val) in energies.into_iter().enumerate() {
-            table.set(e, idx / nj, idx % nj, val);
-        }
+    let slices = table.matrices_mut();
+
+    match (&ff.vdw, c_d) {
+        (VdwMatrix::LennardJones(m), None) => compute::<_, false>(
+            &LjKernel(m),
+            slots,
+            conformations,
+            graph,
+            &ff.hbond,
+            0.0,
+            slices,
+        ),
+        (VdwMatrix::LennardJones(m), Some(c)) => compute::<_, true>(
+            &LjKernel(m),
+            slots,
+            conformations,
+            graph,
+            &ff.hbond,
+            c,
+            slices,
+        ),
+        (VdwMatrix::Buckingham(m), None) => compute::<_, false>(
+            &BuckKernel(m),
+            slots,
+            conformations,
+            graph,
+            &ff.hbond,
+            0.0,
+            slices,
+        ),
+        (VdwMatrix::Buckingham(m), Some(c)) => compute::<_, true>(
+            &BuckKernel(m),
+            slots,
+            conformations,
+            graph,
+            &ff.hbond,
+            c,
+            slices,
+        ),
     }
+
     debug_assert!(graph.edges().iter().enumerate().all(|(e, &(si, sj))| {
         let (ni, nj) = table.dims(e);
         ni == conformations[si as usize].n_candidates()
@@ -73,7 +93,7 @@ struct SlotAtoms<'a> {
     donors: &'a [u8],
 }
 
-/// Parallel over edges × rotamer pairs: compute per-edge energy matrices.
+/// Parallel over edges: compute per-edge energy matrices directly into table slices.
 fn compute<V: VdwKernel + Sync, const COUL: bool>(
     vdw: &V,
     slots: &[Residue],
@@ -81,11 +101,13 @@ fn compute<V: VdwKernel + Sync, const COUL: bool>(
     graph: &ContactGraph,
     hbond: &HBondParams,
     c_d: f32,
-) -> Vec<Vec<f32>> {
+    slices: Vec<&mut [f32]>,
+) {
     graph
         .edges()
         .par_iter()
-        .map(|&(si, sj)| {
+        .zip(slices)
+        .for_each(|(&(si, sj), out)| {
             let (si, sj) = (si as usize, sj as usize);
             let atoms_i = SlotAtoms {
                 types: slots[si].atom_types(),
@@ -99,24 +121,25 @@ fn compute<V: VdwKernel + Sync, const COUL: bool>(
             };
             let confs_i = &conformations[si];
             let confs_j = &conformations[sj];
+            let ni = confs_i.n_candidates();
             let nj = confs_j.n_candidates();
 
-            (0..confs_i.n_candidates() * nj)
-                .into_par_iter()
-                .map(|idx| {
-                    pair_energy::<V, COUL>(
-                        confs_i.coords_of(idx / nj),
+            for ri in 0..ni {
+                let coords_i = confs_i.coords_of(ri);
+                let row = ri * nj;
+                for rj in 0..nj {
+                    out[row + rj] = pair_energy::<V, COUL>(
+                        coords_i,
                         &atoms_i,
-                        confs_j.coords_of(idx % nj),
+                        confs_j.coords_of(rj),
                         &atoms_j,
                         vdw,
                         hbond,
                         c_d,
-                    )
-                })
-                .collect()
-        })
-        .collect()
+                    );
+                }
+            }
+        });
 }
 
 /// Non-bonded pair energy between two candidate conformations.

--- a/crates/dreid-pack/src/pack/phase/prune.rs
+++ b/crates/dreid-pack/src/pack/phase/prune.rs
@@ -107,7 +107,6 @@ fn frame_energies<V: VdwKernel + Sync, const COUL: bool>(
             };
 
             (0..confs.n_candidates())
-                .into_par_iter()
                 .map(|r| self_energy::<V, COUL>(confs.coords_of(r), &atoms, fixed, vdw, hbond, c_d))
                 .collect()
         })


### PR DESCRIPTION
### Summary:

Eliminated redundant work and parallel dispatch overhead across all compute-bound packing phases. DEE: 1.59 s → 0.81 s (−49%) via worklist convergence and prebuilt per-slot neighbor caches. DP adjacency migrated to `BitMatrix` (64-bit packed), reducing memory footprint and simplifying graph-algorithm signatures throughout. Pair energy writes directly to table slices, removing intermediate allocation and a nested parallel loop. DB379 quality unchanged (χ₁–₄ (20°) 71.5%, RMSD 0.728 Å); all 401 tests pass.

### Changes:

- **DEE** (`dee.rs`): Worklist convergence — each round only rechecks slots neighboring a newly pruned slot, skipping unchanged slots entirely. Alive candidates cached per slot (sorted by ascending self-energy for earlier witness hits) and kept in sync with pruning; graph is traversed once before the loop rather than per round. Adaptive parallelism via `with_min_len`.
- **DP** (`dp.rs`): `Vec<bool>` adjacency replaced with `BitMatrix` (u64-packed rows) — denser, cache-friendly, and cleaner API; all graph-algorithm functions (`mcs_order`, `is_peo`, `fill_in`, etc.) simplified accordingly. Standalone `build_alive_table`/`topo_order` helpers inlined into the solve path. Separator DP uses adaptive `with_min_len` parallelism.
- **Energy table** (`energy.rs`): `PairEnergyTable::set()` replaced by `matrices_mut()`, which returns non-overlapping mutable slices via `split_at_mut` for zero-copy parallel bulk writes.
- **Pair energy** (`pair.rs`): `compute()` writes directly into table slices from `matrices_mut()`, eliminating an intermediate `Vec`. Inner rotamer loop made sequential within the per-edge parallel dispatch.
- **Prune** (`prune.rs`): Removed redundant nested parallel iterator from frame energy computation.